### PR TITLE
Changes for upload plugin

### DIFF
--- a/tests/cases/models/behaviors/upload.test.php
+++ b/tests/cases/models/behaviors/upload.test.php
@@ -5,7 +5,7 @@ class TestUpload extends CakeTestModel {
 	var $useTable = 'uploads';
 	var $actsAs = array(
 		'Upload.Upload' => array(
-			'photo'
+			'photo' => array()
 		)
 	);
 }
@@ -15,10 +15,14 @@ class UploadBehaviorTest extends CakeTestCase {
 
 	var $fixtures = array('plugin.upload.upload');
 	var $TestUpload = null;
+	var $MockUpload = null;
 	var $data = array();
+	var $currentTestMethod;
 
-	function startTest() {
+	function startTest($method) {	
 		$this->TestUpload = ClassRegistry::init('TestUpload');
+		$this->currentTestMethod = $method;
+		
 		$this->data['test_ok'] = array(
 			'photo' => array(
 				'name'  => 'Photo.png',
@@ -29,13 +33,128 @@ class UploadBehaviorTest extends CakeTestCase {
 				'error' => UPLOAD_ERR_OK,
 			)
 		);
+		$this->data['test_update'] = array(
+			'id' => 1,
+			'photo' => array(			
+				'name'  => 'NewPhoto.png',
+				'tmp_name'  => 'PhotoTmp.png',
+				'dir'   => '/tmp/php/file.tmp',
+				'type'  => 'image/png',
+				'size'  => 8192,
+				'error' => UPLOAD_ERR_OK,
+			)
+		);		
+		$this->data['test_update_other_field'] = array(
+			'id' => 1,
+			'other_field' => 'test',
+			'photo' => array()
+		);			
 	}
+	
+	function mockUpload($methods) {
+		if (!is_array($methods)) $methods = array($methods);
+		$mockName = $this->currentTestMethod . '_MockUploadBehavior';
+		Mock::GeneratePartial('UploadBehavior', $mockName, $methods);
+		$this->MockUpload = new $mockName();
 
+		$this->MockUpload->setup($this->TestUpload, $this->TestUpload->actsAs['Upload.Upload']);	
+		$this->TestUpload->Behaviors->Upload = $this->MockUpload;
+	}
+	
 	function endTest() {
 		Classregistry::flush();
 		unset($this->TestUpload);
 	}
+	
+	function testFileSize() {
+		$this->mockUpload('handleUploadedFile');
+		$this->MockUpload->setReturnValue('handleUploadedFile', true);
+		
+		$result = $this->TestUpload->save($this->data['test_ok']);
+		$this->assertTrue($result);
+		$newRecord = $this->TestUpload->findById($this->TestUpload->id);
+		$this->assertEqual($this->data['test_ok']['photo']['size'], $newRecord['TestUpload']['size']);
+	}
+	
+	function testSimpleUpload() {
+		$this->mockUpload(array('handleUploadedFile', 'unlink'));
+		$this->MockUpload->setReturnValue('handleUploadedFile', true);
+		$this->MockUpload->setReturnValue('unlink', true);		
+		
+		$this->MockUpload->expectNever('unlink');
+		$this->MockUpload->expectOnce('handleUploadedFile', array($this->data['test_ok']['photo']['tmp_name'], ROOT . DS . APP_DIR . DS . $this->MockUpload->settings['TestUpload']['photo']['path'] . 2 . DS . $this->data['test_ok']['photo']['name']));
+		
+		$result = $this->TestUpload->save($this->data['test_ok']);
+		$this->assertTrue($result);				
+		$newRecord = $this->TestUpload->findById($this->TestUpload->id);
+		
+		$expectedRecord = array(
+			'TestUpload' => array(
+				'id' => 2,
+				'photo' => 'Photo.png',
+				'dir' => 2,
+				'type' => 'image/png',
+				'size' => 8192,
+				'other_field' => null
+			)
+		);
 
+		$this->assertEqual($expectedRecord, $newRecord);
+	}
+	
+	function testDeleteOnUpdate() {
+		$this->TestUpload->actsAs['Upload.Upload']['photo']['deleteOnUpdate'] = true;
+		
+		$this->mockUpload(array('handleUploadedFile', 'unlink'));
+		$this->MockUpload->setReturnValue('handleUploadedFile', true);
+		$this->MockUpload->setReturnValue('unlink', true);		
+		
+		$existingRecord = $this->TestUpload->findById($this->data['test_update']['id']);
+		$this->MockUpload->expectOnce('unlink', array(ROOT . DS . APP_DIR . DS . $this->MockUpload->settings['TestUpload']['photo']['path'] . $existingRecord['TestUpload']['dir'] . DS . $existingRecord['TestUpload']['photo']));
+		$this->MockUpload->expectOnce('handleUploadedFile', array($this->data['test_update']['photo']['tmp_name'], ROOT . DS . APP_DIR . DS . $this->MockUpload->settings['TestUpload']['photo']['path'] . $this->data['test_update']['id'] . DS . $this->data['test_update']['photo']['name']));
+		
+		$result = $this->TestUpload->save($this->data['test_update']);
+		$this->assertTrue($result);			
+	}
+	
+	function testDeleteOnUpdateWithoutNewUpload() {
+		$this->TestUpload->actsAs['Upload.Upload']['photo']['deleteOnUpdate'] = true;
+		
+		$this->mockUpload(array('handleUploadedFile', 'unlink'));		
+		
+		$this->MockUpload->expectNever('unlink');
+		$this->MockUpload->expectNever('handleUploadedFile');
+		
+		$result = $this->TestUpload->save($this->data['test_update_other_field']);
+		$this->assertTrue($result);
+		$newRecord = $this->TestUpload->findById($this->TestUpload->id);
+		$this->assertEqual($this->data['test_update_other_field']['other_field'], $newRecord['TestUpload']['other_field']);
+	}	
+
+	function testUpdateWithoutNewUpload() {		
+		$this->mockUpload(array('handleUploadedFile', 'unlink'));		
+		
+		$this->MockUpload->expectNever('unlink');
+		$this->MockUpload->expectNever('handleUploadedFile');
+		
+		$result = $this->TestUpload->save($this->data['test_update_other_field']);
+		$this->assertTrue($result);
+		$newRecord = $this->TestUpload->findById($this->TestUpload->id);
+		$this->assertEqual($this->data['test_update_other_field']['other_field'], $newRecord['TestUpload']['other_field']);		
+	}		
+	
+	function testUnlinkFileOnDelete() {	
+		$this->mockUpload(array('unlink'));
+		$this->MockUpload->setReturnValue('unlink', true);
+				
+		$existingRecord = $this->TestUpload->findById($this->data['test_update']['id']);
+		$this->MockUpload->expectOnce('unlink', array(ROOT . DS . APP_DIR . DS . $this->MockUpload->settings['TestUpload']['photo']['path'] . $existingRecord['TestUpload']['dir'] . DS . $existingRecord['TestUpload']['photo']));
+		
+		$result = $this->TestUpload->delete($this->data['test_update']['id']);
+		$this->assertTrue($result);			
+		$this->assertFalse($this->TestUpload->findById($this->data['test_update']['id']));
+	}	
+	
 	function testIsUnderPhpSizeLimit() {
 		$this->TestUpload->validate = array(
 			'photo' => array(
@@ -446,8 +565,8 @@ class UploadBehaviorTest extends CakeTestCase {
 		$this->assertFalse($result);
 	}
 
-	function testGetPathRandom() {
-		$result = $this->TestUpload->Behaviors->Upload->_getPathRandom('string', TMP . DIRECTORY_SEPARATOR . 'cache');
+	function testGetPathRandom() {	
+		$result = $this->TestUpload->Behaviors->Upload->_getPathRandom('string', 'tmp' . DIRECTORY_SEPARATOR . 'cache');
 
 		$this->assertIsA($result, 'String');
 		$this->assertEqual(8, strlen($result));
@@ -458,7 +577,7 @@ class UploadBehaviorTest extends CakeTestCase {
 		$result = $this->TestUpload->Behaviors->Upload->_path($this->TestUpload, 'photo', 'webroot{DS}files/{model}\\{field}{DS}');
 
 		$this->assertIsA($result, 'String');
-		$this->assertEqual('webroot/files/test_upload/photo/', $result);
+		$this->assertEqual('webroot' . DIRECTORY_SEPARATOR . 'files' . DIRECTORY_SEPARATOR . 'test_upload' . DIRECTORY_SEPARATOR . 'photo' . DIRECTORY_SEPARATOR, $result);
 	}
 
 	function testPrepareFilesForDeletion() {

--- a/tests/fixtures/upload_fixture.php
+++ b/tests/fixtures/upload_fixture.php
@@ -9,6 +9,7 @@ class UploadFixture extends CakeTestFixture {
 		'dir' => array('type' => 'string', 'null' => true, 'default' => NULL),
 		'type' => array('type' => 'string', 'null' => true, 'default' => NULL),
 		'size' => array('type' => 'integer', 'null' => true, 'default' => NULL),
+		'other_field' => array('type' => 'string', 'null' => true, 'default' => NULL),
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => 1)),
 		'tableParameters' => array('charset' => 'latin1', 'collate' => 'latin1_swedish_ci', 'engine' => 'MyISAM')
 	);
@@ -19,7 +20,7 @@ class UploadFixture extends CakeTestFixture {
 			'photo' => 'Photo.png',
 			'dir' => '1',
 			'type' => 'image/png',
-			'size' => 8192
+			'size' => 8192,			
 		),
 	);
 }


### PR DESCRIPTION
I created some functions to mock the file operations for the plugin so some of the tests I added are making sure that the file is being moved and deleted properly. Fixed some other stuff along the way as well. If I have time I'll add some testing to the image functionality.
- Added tests to check if file is deleted with deleteOnUpdate, deleting file if record is deleted, not touching file is some other field of the record is being saved, moving uploads properly, and saving file size.
- Passing paths through Folder::slashTerm to make sure they end with a slash.
- Fixed bug where if deleteOnUpdate was specified, notice would occur and file would not be saved properly.
- Moved unlink and move_uploaded_file to their own functions to make them easier to mock.
- Added stub "moveUploadedFile" function so Cake doesn't crap out when it cant find the custom validation function. (There is still a more inherit problem that Cake clears all validation after the afterSave is called and user can never actually create a functioning moveUploadedFile rule).
