### PR TITLE
FIX __resizePhp(): create a thumbnails without extension (and $image->se...

### DIFF
--- a/models/behaviors/upload.php
+++ b/models/behaviors/upload.php
@@ -781,10 +781,10 @@ class UploadBehavior extends ModelBehavior {
 			$destFile = $path . $pathInfo['filename'] . '_' . $style . '.' . $pathInfo['extension'];
 		}
 
-		$thumbnailType = $this->settings[$model->alias][$field]['thumbnailType'];
-		if ($thumbnailType && is_string($thumbnailType)) {
-			$image->setImageFormat($thumbnailType);
-		}
+		$thumbnailType = is_string($this->settings[$model->alias][$field]['thumbnailType']) 
+					? $this->settings[$model->alias][$field]['thumbnailType']
+					: $pathInfo['extension'];
+		
 
 		$destFile = $thumbnailPath.$style . '_'.$pathInfo['filename'].".{$thumbnailType}";
 


### PR DESCRIPTION
Upload plugin with resizeMethod = php create a thumbnails images without image's extension. 
[786](https://github.com/josegonzalez/upload/blob/master/models/behaviors/upload.php#L784) $image->setImageFormat($thumbnailType) ($image isn't set) and in [789](https://github.com/josegonzalez/upload/blob/master/models/behaviors/upload.php#L789)   $destFile = $thumbnailType is not set IF settings['thumbnailType'] is  set to false (default=false)
