### PR TITLE
Updated _getMimeType

### DIFF
--- a/models/behaviors/upload.php
+++ b/models/behaviors/upload.php
@@ -1153,8 +1153,12 @@ class UploadBehavior extends ModelBehavior {
 	}
 
 	function _getMimeType($filePath) {
-		$finfo = new finfo(FILEINFO_MIME_TYPE);
-		return $finfo->file($filePath);
+		if (version_compare(PHP_VERSION, '5.3.0') >= 0) {
+			$finfo = new finfo(FILEINFO_MIME_TYPE);
+			return $finfo->file($filePath);
+		} else {
+			return mime_content_type($filePath);
+		}
 	}
 
 	function _prepareFilesForDeletion(&$model, $field, $data, $options) {


### PR DESCRIPTION
Updated _getMimeType to use deprecated mime_content_type() for php version < 5.3

References Issue #39
