### PR TITLE
Notice & Warning when deleting record with no uploads

### DIFF
--- a/models/behaviors/upload.php
+++ b/models/behaviors/upload.php
@@ -328,8 +328,10 @@ class UploadBehavior extends ModelBehavior {
 
 	function afterDelete(&$model) {
 		$result = array();
-		foreach ($this->__filesToRemove[$model->alias] as $file) {
-			$result[] = $this->unlink($file);
+		if(!empty($this->__filesToRemove[$model->alias])) {
+			foreach ($this->__filesToRemove[$model->alias] as $file) {
+				$result[] = $this->unlink($file);
+			}
 		}
 		return $result;
 	}


### PR DESCRIPTION
Notice (8): Undefined index: User [APP/Plugin/Upload/Model/Behavior/UploadBehavior.php, line 329]
Warning (2): Invalid argument supplied for foreach() [APP/Plugin/Upload/Model/Behavior/UploadBehavior.php, line 329]

These errors are given when deleting a record without any uploads.   Fix checks for empty results and skips the Foreach statement if the results are empty.

First pull request so not sure if I got the format exactly right
