### PR TITLE
Case-insensitive extension validation pull request

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -686,7 +686,8 @@ class UploadBehavior extends ModelBehavior {
 		if (empty($extensions)) $extensions = $this->settings[$model->alias][$field]['extensions'];
 		$pathInfo = $this->_pathinfo($check[$field]['name']);
 
-		return in_array($pathInfo['extension'], $extensions);
+		$extensions = array_map('strtolower', $extensions);
+		return in_array(strtolower($pathInfo['extension']), $extensions);
 	}
 
 /**


### PR DESCRIPTION
I noticed that if the valid extensions array is `array('jpg')`, then the extensions .Jpg and .JPG don't pass. Since I can't think of a good reason not to allow case-variations of valid extensions, I modified line 689 from this
`return in_array($pathInfo['extension'], $extensions);`
to this
`return in_array(strtolower($pathInfo['extension']), $extensions);`

And immediately before that line, to allow for the array of valid extensions to be written in either upper or lower case,
`$extensions = array_map('strtolower', $extensions);`
