### PR TITLE
testUnlinkFileOnDelete fixed assert false-empty

### DIFF
--- a/Test/Case/Model/Behavior/UploadTest.php
+++ b/Test/Case/Model/Behavior/UploadTest.php
@@ -193,7 +193,7 @@ class UploadBehaviorTest extends CakeTestCase {
 		);
 		$result = $this->TestUpload->delete($this->data['test_update']['id']);
 		$this->assertTrue($result);
-		$this->assertFalse($this->TestUpload->findById($this->data['test_update']['id']));
+		$this->assertEmpty($this->TestUpload->findById($this->data['test_update']['id']));
 	}
 
 	function testDeleteFileOnRemoveSave() {


### PR DESCRIPTION
CakePHP version 2.2.3

Error occurred:

FAILED
Failed asserting that Array () is false.
Test case: UploadBehaviorTest(testUnlinkFileOnDelete)

Seems the result is ok (an empty array) but the check is not ok. The empty array is the standard response from CakePHP magic findById when no records are found. So that makes sense. However I am not sure why this test was developed then since it should fail. So maybe the CakePHP output changed over time or has a bug in the output value.

The change I think does not influence functionality much since it is just a CakePHP function to check the result of Upload and not an internal of the plugin.
