### PR TITLE
Replace use of double quotes with single quotes

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -287,7 +287,7 @@ class UploadBehavior extends ModelBehavior {
 			if ($model->hasField($options['fields']['dir'])) {
 				if ($created && $options['pathMethod'] == '_getPathFlat') {
 				} else if ($options['saveDir']) {
-					$temp[$model->alias][$options['fields']['dir']] = "\"{$tempPath}\"";
+					$temp[$model->alias][$options['fields']['dir']] = "'{$tempPath}'";
 				}
 			}
 		}


### PR DESCRIPTION
Single quotes are used to delimit literals in the SQL standard; MySQL accepts either, but other databases may not (and PostgreSQL, where I encountered the problem, definitely doesn't).
