### PR TITLE
Fix: Empty 'remove' field no longer deletes files

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -213,7 +213,7 @@ class UploadBehavior extends ModelBehavior {
 
 			$this->runtime[$model->alias][$field] = $model->data[$model->alias][$field];
 
-			$removing = isset($model->data[$model->alias][$field]['remove']);
+			$removing = !empty($model->data[$model->alias][$field]['remove']);
 			if ($removing || ($this->settings[$model->alias][$field]['deleteOnUpdate']
 			&& isset($model->data[$model->alias][$field]['name'])
 			&& strlen($model->data[$model->alias][$field]['name']))) {

--- a/Test/Case/Model/Behavior/UploadTest.php
+++ b/Test/Case/Model/Behavior/UploadTest.php
@@ -277,7 +277,7 @@ class UploadBehaviorTest extends CakeTestCase {
 		$this->assertEmpty($this->TestUpload->findById($this->data['test_update']['id']));
 	}
 
-	function testDeleteFileOnRemoveSave() {
+	function testDeleteFileOnTrueRemoveSave() {
 		$this->mockUpload();
 		$this->MockUpload->expects($this->once())->method('unlink')->will($this->returnValue(true));
 
@@ -292,6 +292,38 @@ class UploadBehaviorTest extends CakeTestCase {
 		$this->MockUpload->expects($this->once())->method('unlink')->with(
 			$this->MockUpload->settings['TestUpload']['photo']['path'] . $existingRecord['TestUpload']['dir'] . DS . $existingRecord['TestUpload']['photo']
 		);
+		$result = $this->TestUpload->save($data);
+		$this->assertInternalType('array', $result);
+	}
+	
+	function testKeepFileOnFalseRemoveSave() {
+		$this->mockUpload();
+		$this->MockUpload->expects($this->never())->method('unlink');
+
+		$data = array(
+			'id' => 1,
+			'photo' => array(
+				'remove' => false
+			)
+		);
+
+		$existingRecord = $this->TestUpload->findById($data['id']);
+		$result = $this->TestUpload->save($data);
+		$this->assertInternalType('array', $result);
+	}
+	
+	function testKeepFileOnNullRemoveSave() {
+		$this->mockUpload();
+		$this->MockUpload->expects($this->never())->method('unlink');
+
+		$data = array(
+			'id' => 1,
+			'photo' => array(
+				'remove' => null
+			)
+		);
+
+		$existingRecord = $this->TestUpload->findById($data['id']);
 		$result = $this->TestUpload->save($data);
 		$this->assertInternalType('array', $result);
 	}


### PR DESCRIPTION
As you probably know:
- 'isset' returns true if a variable or array key is instantiated (even if it contains 'null' or 'false')
- 'empty' returns true if a variable or array key is NOT instantiated, OR holds a value that evaluates to false.
  (I'm sure you don't need it, but lots more explanation here: http://kunststube.net/isset/)

Previously, an 'isset' was used to determine if a 'remove' field existed, and if so, files were deleted. This meant that even an unchecked 'remove' checkbox in your form would delete the files.

I've changed the test to use '!empty', so that files will only be deteled if the 'remove' field a) exists in the array, and b) contains a value that doesn't evaluate to false.

So now you can include a 'remove' checkbox along with every upload field, and files will only be deleted when the user checks it. Note that if you do NOT include a remove field at all, this does NOT result in an error, and files will of course not be deleted.

Signed-off-by: Joshua Paling joshua.paling@gmail.com
