### PR TITLE
Update UploadBehavior.php

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -316,7 +316,8 @@ class UploadBehavior extends ModelBehavior {
 		return @unlink($file);
 	}
 
-	public function deleteFolder($path, $folders) {
+	public function deleteFolder($model, $path) {
+		$folders = $this->__foldersToRemove[$model->alias];
 		foreach ( $folders as $folder ) {
 			$dir = $path . $folder;
 			$it = new RecursiveDirectoryIterator($dir);
@@ -326,14 +327,12 @@ class UploadBehavior extends ModelBehavior {
 					continue;
 				}
 				if ($file->isDir()) {
-					// error suppression?
-					rmdir($file->getRealPath());
+					@rmdir($file->getRealPath());
 				} else {
-					// error suppression?
-					unlink($file->getRealPath());
+					@unlink($file->getRealPath());
 				}
 			}
-			rmdir($dir);
+			@rmdir($dir);
 		}
 	}
 
@@ -360,7 +359,7 @@ class UploadBehavior extends ModelBehavior {
 
 		foreach ($this->settings[$model->alias] as $field => $options) {
 			if ($options['deleteFolderOnDelete'] == true) {
-				$this->deleteFolder($options['path'], $this->__foldersToRemove[$model->alias]);
+				$this->deleteFolder($model, $options['path']);
 				return true;
 			}
 		}


### PR DESCRIPTION
Made most of Jose's recommendations. Still some work to do, but getting there.

A few notes:

1) I've name spaced folders to an array like Jose recommended... and I'm sending the array to my deletion script, by plucking based on model alias... is this a correct approach?

```
$this->deleteFolder($options['path'], $this->__foldersToRemove[$model->alias]);
```

2) I'm not sure what you had in mind for folder deletion error suppression. You mean if a folder is not present, but deletion is attempted? Right now, if a file does not exist (let's say a thumbnail got deleted manually in FTP), the script will crash. In most cases, the assumption is that people are not manually editing the actually files on disk, and is letting the Upload Behavior handle all the file management.

Thoughts?
