### PR TITLE
Fixes issue #97 - invalid param for imagepng()

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -997,6 +997,7 @@ class UploadBehavior extends ModelBehavior {
 		}
 
 		$supportsThumbnailQuality = false;
+		$adjustedThumbnailQuality = $this->settings[$model->alias][$field]['thumbnailQuality'];
 		switch (strtolower($thumbnailType)) {
 			case 'gif':
 				$outputHandler = 'imagegif';
@@ -1009,6 +1010,8 @@ class UploadBehavior extends ModelBehavior {
 			case 'png':
 				$outputHandler = 'imagepng';
 				$supportsThumbnailQuality = true;
+				// convert 0 (lowest) - 100 (highest) thumbnailQuality, to 0 (highest) - 9 (lowest) quality (see http://php.net/manual/en/function.imagepng.php)
+				$adjustedThumbnailQuality = intval((100 - $this->settings[$model->alias][$field]['thumbnailQuality'])/100*9);
 				break;
 			default:
 				return false;
@@ -1075,7 +1078,7 @@ class UploadBehavior extends ModelBehavior {
 			imagecopyresampled($img, $src, ($destW-$resizeW)/2, ($destH-$resizeH)/2, 0, 0, $resizeW, $resizeH, $srcW, $srcH);
 
 			if ($supportsThumbnailQuality) {
-				$outputHandler($img, $destFile, $this->settings[$model->alias][$field]['thumbnailQuality']);
+				$outputHandler($img, $destFile, $adjustedThumbnailQuality);
 			} else {
 				$outputHandler($img, $destFile);
 			}


### PR DESCRIPTION
As mentioned here: https://github.com/josegonzalez/upload/pull/97, in _resizePhp(), I've converted the 0-100 thumbnailQuality to it's corresponding 0-9 value for use with imagepng().

I've tested it thoroughly, but haven't written Unit Tests... I did look into this, but I'm not sure if it can be done properly without refactoring code and breaking _resizePhp() into smaller testable private methods or something.

What you'd really want to do is set up a test case asserting that imagepng() gets called once with third parameter between 0 and 9. But since imagepng() is an in-built method of PHP, you can't do that, unless you wrote a wrapper function for it, right?

It looks like most of the code & options in _resizePhp() isn't explicitly tested at the moment, anyway. Correct?

I don't have a lot of experience in unit testing, so I'm happy to be proven wrong, and I'm happy to write tests and amend this pull request if anyone has a suggestion of how to do it nicely.

Signed-off-by: Joshua Paling joshua.paling@gmail.com
