### PR TITLE
Fixed imagick banding

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -872,8 +872,8 @@ class UploadBehavior extends ModelBehavior {
 			list($destW, $destH) = explode('x', substr($geometry, 1, strlen($geometry)-2));
 			$image->thumbnailImage($destW, $destH, true);
 			$imageGeometry = $image->getImageGeometry();
-			$x = ($destW - $imageGeometry['width']) / 2;
-			$y = ($destH - $imageGeometry['height']) / 2;
+			$x = ($imageGeometry['width'] - $destW) / 2;
+			$y = ($imageGeometry['height'] - $destH) / 2;
 			$image->setGravity(Imagick::GRAVITY_CENTER);
 			$image->extentImage($destW, $destH, $x, $y);
 		} elseif (preg_match('/^[\\d]+x[\\d]+$/', $geometry)) {


### PR DESCRIPTION
Offsets of `Imagick::extentImage()` should be negative for lengths shorter than destination length.
