### PR TITLE
Typo in UploadBehavior::_createThumbnails

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -1308,7 +1308,7 @@ class UploadBehavior extends ModelBehavior {
 				$thumbnailPathSized = $this->_pathThumbnail($model, $field, compact(
 					'geometry', 'size', 'thumbnailPath'
 				));
-				$this->_mkPath($Model, $field, $thumbnailPathSized);
+				$this->_mkPath($model, $field, $thumbnailPathSized);
 
 				$valid = false;
 				if (method_exists($model, $method)) {


### PR DESCRIPTION
I just fixed a typo in UploadBehavior line 1311. using $Model instead of $model
