### PR TITLE
add validation: isFileUploadOrHasExistingValue

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -489,6 +489,29 @@ class UploadBehavior extends ModelBehavior {
 	}
 
 /**
+ * Check that either a file was uploaded,
+ * or the existing value in the database is not blank.
+ *
+ * @param Object $model
+ * @param mixed $check Value to check
+ * @return boolean Success
+ * @access public
+ */
+	public function isFileUploadOrHasExistingValue(Model $model, $check) {
+		if(!$this->isFileUpload($model, $check)){
+			$pkey = $model->primaryKey;
+			if($model->data[$model->alias][$pkey]){
+				$field = $this->_getField($check);
+				$fieldValue = $model->field($field, array($pkey => $model->data[$model->alias][$pkey]));
+				return !empty($fieldValue);
+			} else {
+				return false; // New record - there cannot be an existing value
+			}
+		}
+		return true;
+	}
+
+/**
  * Check that the PHP temporary directory is missing
  *
  * @param Object $model

--- a/README.markdown
+++ b/README.markdown
@@ -524,6 +524,17 @@ Check that a file was uploaded
 		)
 	);
 
+#### isFileUploadOrHasExistingValue
+
+Check that either a file was uploaded, or the existing value in the database is not blank
+
+	public $validate = array(
+		'photo' => array(
+			'rule' => 'isFileUploadOrHasExistingValue',
+			'message' => 'File was missing from submission'
+		)
+	);
+
 #### tempDirExists
 
 Check that the PHP temporary directory is missing


### PR DESCRIPTION
for situations where a user should be allowed to save a form without uploading a file, but only if the existing value in the database is not blank.

(my situation: a user has a profile form, including a profile image. They must upload an image - but if they've already uploaded one, they should be able to edit the other fields in the form and save, without having to upload another image)

Signed-off-by: Joshua Paling joshua.paling@gmail.com
