### PR TITLE
fix 'Undefined index: id' errors in isFileUploadOrHasExistingValue when ...

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -498,9 +498,9 @@ class UploadBehavior extends ModelBehavior {
  * @access public
  */
 	public function isFileUploadOrHasExistingValue(Model $model, $check) {
-		if(!$this->isFileUpload($model, $check)){
+		if (!$this->isFileUpload($model, $check)) {
 			$pkey = $model->primaryKey;
-			if($model->data[$model->alias][$pkey]){
+			if (!empty($model->data[$model->alias][$pkey])) {
 				$field = $this->_getField($check);
 				$fieldValue = $model->field($field, array($pkey => $model->data[$model->alias][$pkey]));
 				return !empty($fieldValue);

--- a/Test/Fixture/UploadFixture.php
+++ b/Test/Fixture/UploadFixture.php
@@ -20,7 +20,15 @@ class UploadFixture extends CakeTestFixture {
 			'photo' => 'Photo.png',
 			'dir' => '1',
 			'type' => 'image/png',
-			'size' => 8192	
+			'size' => 8192
+		),
+		array(
+			// Intentionally empty record, for testing isFileUploadOrHasExistingValue validation
+			'id' => 2,
+			'photo' => '',
+			'dir' => '',
+			'type' => '',
+			'size' => 0
 		),
 	);
 }


### PR DESCRIPTION
...adding new record

I usually merge my add and edit views, so even an add view will have an id field, but it will be empty. However, if you use a separate add view, with no id field, then you'll get an "undefined index" error when using the isFileUploadOrHasExistingValue validation. This commit prevents that error.

Signed-off-by: Joshua Paling joshua.paling@gmail.com
