### PR TITLE
Fix method signature for CakePHP 2.4.1 to fix E_STRICT warnings

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -210,7 +210,7 @@ class UploadBehavior extends ModelBehavior {
  * @param AppModel $model Model instance
  * @return boolean
  */
-	public function beforeSave(Model $model) {
+	public function beforeSave(Model $model, $options = array()) {
 		$this->_removingOnly = array();
 		foreach ($this->settings[$model->alias] as $field => $options) {
 			if (!isset($model->data[$model->alias][$field])) continue;
@@ -269,7 +269,7 @@ class UploadBehavior extends ModelBehavior {
 	 * Transform Model.field value like as PHP upload array (name, tmp_name)
 	 * for UploadBehavior plugin processing.
 	 */
-	function beforeValidate(Model $model) {
+	function beforeValidate(Model $model, $options = array()) {
 		foreach ($this->settings[$model->alias] as $field => $options) {
 			if (!empty($model->data[$model->alias][$field])
 				AND $this->_isURI($model->data[$model->alias][$field])) {
@@ -283,7 +283,7 @@ class UploadBehavior extends ModelBehavior {
 		return true;
 	}
 
-	public function afterSave(Model $model, $created) {
+	public function afterSave(Model $model, $created, $options = array()) {
 		$temp = array($model->alias => array());
 
 		foreach ($this->settings[$model->alias] as $field => $options) {


### PR DESCRIPTION
See: http://bakery.cakephp.org/articles/markstory/2013/09/15/cakephp_2_4_1_released

Method signatures in CakePHP's ModelBehavior class were evidently fixed in 2.4.1. These three were the only ones showing E_STRICT messages for me.

Suppose you may also want to reconsider using `$options` variable in the foreach in this case. But the code doesn't break, so not a big deal, just confusing.
