### PR TITLE
add doco for installing with composer

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -39,6 +39,18 @@ In your `Plugin` directory type:
 
 	git clone -b master git://github.com/josegonzalez/upload.git Upload
 
+_[Using [Composer](http://getcomposer.org/)]_
+
+Add the plugin to your project's `composer.json` - something like this:
+
+	{
+		"require": {
+			"josegonzalez/upload": "dev-master"
+		}
+	}
+
+Because this plugin has the type `cakephp-plugin` set in it's own `composer.json`, composer knows to install it inside your `/Plugins` directory, rather than in the usual vendors file. It is recommended that you add `/Plugins/Upload` to your .gitignore file. (Why? [read this](http://getcomposer.org/doc/faqs/should-i-commit-the-dependencies-in-my-vendor-directory.md).)
+
 ### Imagick Support
 
 To enable Imagick support, you need to have imagick installed:


### PR DESCRIPTION
Add doco in the readme for installing with composer.

You probably don't want to take it this far, but I reckon the composer instructions should not only be added, but also be pushed higher up and marked as the recommended way to install. The quicker everyone in the PHP community (including newbies) takes on composer/packagist as the defacto way to handle dependencies, the better.

Signed-off-by: Joshua Paling joshua.paling@gmail.com
