### PR TITLE
add private methods for common assertions

### DIFF
--- a/Test/Case/Model/Behavior/UploadTest.php
+++ b/Test/Case/Model/Behavior/UploadTest.php
@@ -391,13 +391,7 @@ class UploadBehaviorTest extends CakeTestCase {
 		$this->assertEqual(1, count($this->TestUpload->validationErrors));
 		$this->assertEqual('isUnderPhpSizeLimit', current($this->TestUpload->validationErrors['photo']));
 
-		$this->TestUpload->set($this->data['test_ok']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
-
-		$this->TestUpload->set($this->data['test_remove']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->__testOkAndRemoveCasesValidate();
 	}
 
 	public function testIsUnderFormSizeLimit() {
@@ -424,13 +418,7 @@ class UploadBehaviorTest extends CakeTestCase {
 		$this->assertEqual(1, count($this->TestUpload->validationErrors));
 		$this->assertEqual('isUnderFormSizeLimit', current($this->TestUpload->validationErrors['photo']));
 
-		$this->TestUpload->set($this->data['test_ok']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
-
-		$this->TestUpload->set($this->data['test_remove']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->__testOkAndRemoveCasesValidate();
 	}
 
 	public function testIsCompletedUpload() {
@@ -457,13 +445,7 @@ class UploadBehaviorTest extends CakeTestCase {
 		$this->assertEqual(1, count($this->TestUpload->validationErrors));
 		$this->assertEqual('isCompletedUpload', current($this->TestUpload->validationErrors['photo']));
 
-		$this->TestUpload->set($this->data['test_ok']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
-
-		$this->TestUpload->set($this->data['test_remove']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->__testOkAndRemoveCasesValidate();
 	}
 
 	public function testIsFileUpload() {
@@ -490,13 +472,7 @@ class UploadBehaviorTest extends CakeTestCase {
 		$this->assertEqual(1, count($this->TestUpload->validationErrors));
 		$this->assertEqual('isFileUpload', current($this->TestUpload->validationErrors['photo']));
 
-		$this->TestUpload->set($this->data['test_ok']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
-
-		$this->TestUpload->set($this->data['test_remove']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->__testOkAndRemoveCasesValidate();
 	}
 
 /**
@@ -527,13 +503,7 @@ class UploadBehaviorTest extends CakeTestCase {
 		$this->assertTrue($this->TestUpload->validates());
 		$this->assertEqual(0, count($this->TestUpload->validationErrors));
 
-		$this->TestUpload->set($this->data['test_ok']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
-
-		$this->TestUpload->set($this->data['test_remove']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->__testOkAndRemoveCasesValidate();
 	}
 
 /**
@@ -565,13 +535,7 @@ class UploadBehaviorTest extends CakeTestCase {
 		$this->assertEqual(1, count($this->TestUpload->validationErrors));
 		$this->assertEqual('isFileUploadOrHasExistingValue', current($this->TestUpload->validationErrors['photo']));
 
-		$this->TestUpload->set($this->data['test_ok']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
-
-		$this->TestUpload->set($this->data['test_remove']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->__testOkAndRemoveCasesValidate();
 	}
 
 /**
@@ -603,13 +567,7 @@ class UploadBehaviorTest extends CakeTestCase {
 		$this->assertEqual(1, count($this->TestUpload->validationErrors));
 		$this->assertEqual('isFileUploadOrHasExistingValue', current($this->TestUpload->validationErrors['photo']));
 
-		$this->TestUpload->set($this->data['test_ok']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
-
-		$this->TestUpload->set($this->data['test_remove']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->__testOkAndRemoveCasesValidate();
 	}
 
 /**
@@ -641,13 +599,7 @@ class UploadBehaviorTest extends CakeTestCase {
 		$this->assertEqual(1, count($this->TestUpload->validationErrors));
 		$this->assertEqual('isFileUploadOrHasExistingValue', current($this->TestUpload->validationErrors['photo']));
 
-		$this->TestUpload->set($this->data['test_ok']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
-
-		$this->TestUpload->set($this->data['test_remove']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->__testOkAndRemoveCasesValidate();
 	}
 
 	public function testTempDirExists() {
@@ -674,13 +626,7 @@ class UploadBehaviorTest extends CakeTestCase {
 		$this->assertEqual(1, count($this->TestUpload->validationErrors));
 		$this->assertEqual('tempDirExists', current($this->TestUpload->validationErrors['photo']));
 
-		$this->TestUpload->set($this->data['test_ok']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
-
-		$this->TestUpload->set($this->data['test_remove']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->__testOkAndRemoveCasesValidate();
 	}
 
 	public function testIsSuccessfulWrite() {
@@ -707,13 +653,7 @@ class UploadBehaviorTest extends CakeTestCase {
 		$this->assertEqual(1, count($this->TestUpload->validationErrors));
 		$this->assertEqual('isSuccessfulWrite', current($this->TestUpload->validationErrors['photo']));
 
-		$this->TestUpload->set($this->data['test_ok']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
-
-		$this->TestUpload->set($this->data['test_remove']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->__testOkAndRemoveCasesValidate();
 	}
 
 	public function testNoPhpExtensionErrors() {
@@ -740,13 +680,7 @@ class UploadBehaviorTest extends CakeTestCase {
 		$this->assertEqual(1, count($this->TestUpload->validationErrors));
 		$this->assertEqual('noPhpExtensionErrors', current($this->TestUpload->validationErrors['photo']));
 
-		$this->TestUpload->set($this->data['test_ok']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
-
-		$this->TestUpload->set($this->data['test_remove']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->__testOkAndRemoveCasesValidate();
 	}
 
 	public function testIsValidMimeType() {
@@ -778,13 +712,7 @@ class UploadBehaviorTest extends CakeTestCase {
 			)
 		));
 
-		$this->TestUpload->set($this->data['test_ok']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
-
-		$this->TestUpload->set($this->data['test_remove']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->__testOkAndRemoveCasesValidate();
 
 		$this->TestUpload->validate = array(
 			'photo' => array(
@@ -795,9 +723,7 @@ class UploadBehaviorTest extends CakeTestCase {
 			)
 		);
 
-		$this->TestUpload->set($this->data['test_ok']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->__testOkCaseValidates();
 	}
 
 	public function testIsValidExtension() {
@@ -852,9 +778,7 @@ class UploadBehaviorTest extends CakeTestCase {
 		$this->assertEqual('isValidExtension', current($this->TestUpload->validationErrors['photo']));
 
 		$this->TestUpload->validate['photo']['isValidExtension']['rule'] = array('isValidExtension', array('jpg', 'bmp', 'png'));
-		$this->TestUpload->set($this->data['test_ok']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->__testOkCaseValidates();
 
 		$this->TestUpload->validate = array(
 			'photo' => array(
@@ -880,9 +804,7 @@ class UploadBehaviorTest extends CakeTestCase {
 		$this->assertEqual(1, count($this->TestUpload->validationErrors));
 		$this->assertEqual('isValidExtension', current($this->TestUpload->validationErrors['photo']));
 
-		$this->TestUpload->set($this->data['test_remove']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->__testRemoveCaseValidates();
 	}
 
 	public function testIsWritable() {
@@ -921,9 +843,7 @@ class UploadBehaviorTest extends CakeTestCase {
 		$this->assertTrue($this->TestUpload->validates());
 		$this->assertEqual(0, count($this->TestUpload->validationErrors));
 
-		$this->TestUpload->set($this->data['test_remove']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->__testRemoveCaseValidates();
 	}
 
 	public function testIsValidDir() {
@@ -962,9 +882,7 @@ class UploadBehaviorTest extends CakeTestCase {
 		$this->assertTrue($this->TestUpload->validates());
 		$this->assertEqual(0, count($this->TestUpload->validationErrors));
 
-		$this->TestUpload->set($this->data['test_remove']);
-		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->__testRemoveCaseValidates();
 	}
 
 	public function testIsImage() {
@@ -1254,6 +1172,23 @@ class UploadBehaviorTest extends CakeTestCase {
 		$this->assertInternalType('array', $result);
 		$this->assertEqual(1, count($result));
 		$this->assertEqual(4, count($result['TestUpload']));
+	}
+
+	private function __testOkAndRemoveCasesValidate() {
+		$this->__testOkCaseValidates();
+		$this->__testRemoveCaseValidates();
+	}
+
+	private function __testOkCaseValidates() {
+		$this->TestUpload->set($this->data['test_ok']);
+		$this->assertTrue($this->TestUpload->validates());
+		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+	}
+
+	private function __testRemoveCaseValidates() {
+		$this->TestUpload->set($this->data['test_remove']);
+		$this->assertTrue($this->TestUpload->validates());
+		$this->assertEqual(0, count($this->TestUpload->validationErrors));
 	}
 
 }


### PR DESCRIPTION
Dunno if you want this... anyway. Several test cases check that the 'OK', and/or the 'remove' data both validate. I've just pulled the logic out into private methods to keep things DRY.

Signed-off-by: Joshua Paling joshua.paling@gmail.com
