### PR TITLE
honour exif data for jpg thumbnails (aka, prevent thumbnails showing up sideways)

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -950,6 +950,7 @@ class UploadBehavior extends ModelBehavior {
 		}
 
 		$image->readImage($srcFile);
+		$this->_exifRotateImagick($image);
 		$height = $image->getImageHeight();
 		$width = $image->getImageWidth();
 
@@ -1065,22 +1066,7 @@ class UploadBehavior extends ModelBehavior {
 
 		copy($srcFile, $destFile);
 		$src = null;
-		$createHandler = null;
 		$outputHandler = null;
-		switch (strtolower($pathInfo['extension'])) {
-			case 'gif':
-				$createHandler = 'imagecreatefromgif';
-				break;
-			case 'jpg':
-			case 'jpeg':
-				$createHandler = 'imagecreatefromjpeg';
-				break;
-			case 'png':
-				$createHandler = 'imagecreatefrompng';
-				break;
-			default:
-				return false;
-		}
 
 		$supportsThumbnailQuality = false;
 		$adjustedThumbnailQuality = $this->settings[$model->alias][$field]['thumbnailQuality'];
@@ -1103,7 +1089,9 @@ class UploadBehavior extends ModelBehavior {
 				return false;
 		}
 
-		if ($src = $createHandler($destFile)) {
+		$src = $this->_createImageResource($destFile, $pathInfo);
+		if ($src) {
+
 			$srcW = imagesx($src);
 			$srcH = imagesy($src);
 
@@ -1190,6 +1178,158 @@ class UploadBehavior extends ModelBehavior {
 			return true;
 		}
 		return false;
+	}
+
+	protected function _createImageResource($filename, $pathInfo) {
+		switch (strtolower($pathInfo['extension'])) {
+			case 'gif':
+				$src = imagecreatefromgif($filename);
+				break;
+			case 'jpg':
+			case 'jpeg':
+				$src = $this->_imagecreatefromjpegexif($filename);
+				break;
+			case 'png':
+				$src = imagecreatefrompng($filename);
+				break;
+			default:
+				return false;
+		}
+
+		return $src;
+	}
+
+/**
+ * Same as imagecreatefromjpeg, but honouring the file's Exif data.
+ * See http://www.php.net/manual/en/function.imagecreatefromjpeg.php#112902
+ */
+	protected function _imagecreatefromjpegexif($filename) {
+		$image = imagecreatefromjpeg($filename);
+		$exif = exif_read_data($filename);
+		if ($image && $exif && isset($exif['Orientation'])) {
+			$ort = $exif['Orientation'];
+		} else {
+			return $image;
+		}
+
+		$trans = $this->_exifOrientationTransformations($ort);
+
+		if ($trans['flip_vert']) {
+			$image = $this->_flipImage($image,'vert');
+		}
+
+		if ($trans['flip_horz']) {
+			$image = $this->_flipImage($image,'horz');
+		}
+
+		if ($trans['rotate_clockwise']) {
+			$image = imagerotate($image, -1 * $trans['rotate_clockwise'], 0);
+		}
+
+		return $image;
+	}
+
+/**
+ * Determine what transformations need to be applied to an image,
+ * in order to maintain it's orientation and get rid of it's Exif Orientation data
+ * http://www.impulseadventure.com/photo/exif-orientation.html
+ * @param  int $orientation The exif orientation of the image
+ * @return array of transformations - array keys are:
+ * 'flip_vert' - true if the image needs to be flipped vertically
+ * 'flip_horz' - true if the image needs to be flipped horizontally
+ * 'rotate_clockwise' - number of degrees image needs to be rotated, clockwise
+ */
+	protected function _exifOrientationTransformations($orientation) {
+		$trans = array(
+			'flip_vert' => false,
+			'flip_horz' => false,
+			'rotate_clockwise' => 0,
+		);
+
+		switch($orientation) {
+			case 1:
+				break;
+
+			case 2:
+				$trans['flip_horz'] = true;
+				break;
+
+			case 3:
+				$trans['rotate_clockwise'] = 180;
+				break;
+
+			case 4:
+				$trans['flip_vert'] = true;
+				break;
+
+			case 5:
+				$trans['flip_vert'] = true;
+				$trans['rotate_clockwise'] = 90;
+				break;
+
+			case 6:
+				$trans['rotate_clockwise'] = 90;
+				break;
+
+			case 7:
+				$trans['flip_horz'] = true;
+				$trans['rotate_clockwise'] = 90;
+				break;
+
+			case 8:
+				$trans['rotate_clockwise'] = -90;
+				break;
+		}
+
+		return $trans;
+	}
+
+/**
+ * Flip an image object. Code from http://www.roscripts.com/snippets/show/55
+ * @param  resource $img An image resource, such as one returned by imagecreatefromjpeg()
+ * @param  string $type 'horz' or 'vert'
+ * @return resource The flipped image
+ */
+	protected function _flipImage($img, $type) {
+		$width = imagesx($img);
+		$height = imagesy($img);
+		$dest = imagecreatetruecolor($width, $height);
+		switch($type){
+			case 'vert':
+				for ($i = 0; $i < $height; $i++) {
+					imagecopy($dest, $img, 0, ($height - $i - 1), 0, $i, $width, 1);
+				}
+				break;
+			case 'horz':
+				for ($i = 0; $i < $width; $i++) {
+					imagecopy($dest, $img, ($width - $i - 1), 0, $i, 0, 1, $height);
+				}
+				break;
+		}
+		return $dest;
+	}
+
+/**
+ * rotate an imagick object based on it's exif data.
+ * @param  imagick $image an instance of imagick
+ */
+	protected function _exifRotateImagick($image) {
+		$orientation = $image->getImageOrientation();
+		$trans = $this->_exifOrientationTransformations($orientation);
+
+		if ($trans['flip_vert']) {
+			$image->flopImage();
+		}
+
+		if ($trans['flip_horz']) {
+			$image->flipImage();
+		}
+
+		if ($trans['rotate_clockwise']) {
+			$image->rotateimage("#000", $trans['rotate_clockwise']);
+		}
+
+		$image->setImageOrientation(imagick::ORIENTATION_TOPLEFT);
 	}
 
 	protected function _getPath(Model $model, $field) {


### PR DESCRIPTION
OK... this is a pretty important issue - no idea how this hasn't come up before, but about a hundred users have just signed up to a site I'm doing, and a decent percentage have sideways profile thumbnails!

The reason is this plugin doesn't honour an images exif orientation data, meaning that many photos, when uploaded, have their thumbnails sideways / upside down, etc.

This pull request fixes that - and doesn't change anything for images which are not JPG's with Exif Orientation data.

You probably know most of this, but I'll assume no knowledge just in case...
Some JPG's store "Exif" data, containing info like the images geolocation, and, importantly, orientation. If a camera is held eg. upside down to take a photo, the raw image is stored upside down, but the Exif Orientation data indicates that it should be rotated 180 degrees to be displayed.

Since most browsers interpret exif data, original images uploaded with this plugin will display fine - but the thumbnails made from them will not, because the exif data isn't transformed to the thumbnail. This pull request checks for exif orientation data in an image, and if it's present, adjusts the image appropriately (flips or rotates it). So, the thumbnail will be adjusted to display correctly, without the exif data.

I've followed this to get image orientation from exif data: http://www.impulseadventure.com/photo/exif-orientation.html

I've got no idea how you'd write tests for this, since the uploads themselves are mocked... if you've got ideas for how to auto-test, I'm happy to write the tests.

I have tested thoroughly, manually. I've tested images with exif orientations of 1, 3, 6 and 8, and I've tested for both php and imagick thumbnail methods. The other 4 orientation cases - 2, 4, 5, and 7 - are rare; they are when the image is flipped, and I don't have a camera that produces them. But I've coded carefully, and in any case, those cases can't be more broken than they already are!

If you want to test manually, here are some images with different exif orientation values (not sure if github will preserve the exif data, but you can make your own by just taking 4 photos with your iphone, rotating 90 degrees more for each one.

(UPDATE - as you can see, Github doesn't honour the exif data when displaying the images inline, but open each in a new tab and it will display correctly)

exif 6
![exif6](https://f.cloud.github.com/assets/145042/1244796/e9fcab16-2a8e-11e3-9f57-c0c6733e90b4.JPG)

exif 8
![exif8](https://f.cloud.github.com/assets/145042/1244797/ea7f124a-2a8e-11e3-9ff6-bf55e7b47fc4.JPG)

exif 3
![exif3](https://f.cloud.github.com/assets/145042/1244798/eab9b9b8-2a8e-11e3-9cd1-9ea1cfe0d47b.JPG)

exif 1
![exif1](https://f.cloud.github.com/assets/145042/1244799/eb3c6994-2a8e-11e3-9077-c9b2c6f6d83d.JPG)

Signed-off-by: Joshua Paling joshua.paling@gmail.com
