### PR TITLE
Remove files from UploadBehavior::__filesToRemove after unlinking

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -356,8 +356,9 @@ class UploadBehavior extends ModelBehavior {
 		if (empty($this->__filesToRemove[$model->alias])) {
 			return true;
 		}
-		foreach ($this->__filesToRemove[$model->alias] as $file) {
+		foreach ($this->__filesToRemove[$model->alias] as $i => $file) {
 			$result[] = $this->unlink($file);
+			unset($this->__filesToRemove[$model->alias][$i]);
 		}
 		return $result;
 	}
@@ -417,8 +418,9 @@ class UploadBehavior extends ModelBehavior {
 	public function afterDelete(Model $model) {
 		$result = array();
 		if (!empty($this->__filesToRemove[$model->alias])) {
-			foreach ($this->__filesToRemove[$model->alias] as $file) {
+			foreach ($this->__filesToRemove[$model->alias] as $i => $file) {
 				$result[] = $this->unlink($file);
+				unset($this->__filesToRemove[$model->alias][$i]);
 			}
 		}
 


### PR DESCRIPTION
This prevents the plugin from attempting to delete a file a second time
if an associated media file is deleted before the main model is saved.
Otherwise, the plugin will attempt to unlink the files in
UploadBehavior::__filesToRemove in UploadBehavior::afterDelete() and
then again in UploadBehavior::afterSave().
