### PR TITLE
Disable HttpSocket's ssl_verify_host

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -1205,7 +1205,9 @@ class UploadBehavior extends ModelBehavior {
 	 * Download remote file into PHP's TMP dir
 	 */
 	public function _grab(Model $model, $field, $uri) {
-		$socket = new HttpSocket();
+		$socket = new HttpSocket(array(
+			'ssl_verify_host' => false
+		));
 		$file = $socket->get($uri, array(), array('redirect' => true));
 		$headers = $socket->response['header'];
 		$file_name = basename($socket->request['uri']['path']);


### PR DESCRIPTION
I'm no SSL guru, so you could perhaps leave this for debate if you want.

To replicate the problem, just try to use any SSL youtube thumbnail for remote download by the Upload Behavior.
(e.g. https://i1.ytimg.com/vi/kspPE9E1yGM/mqdefault.jpg)

```
Error: stream_socket_client(): Peer certificate CN=`*.google.com' did not match expected CN=`i1.ytimg.com'
```

This seems to be a general problem with CakePHP's HttpSocket (maybe even PHP itself) as discussed in one of their tickets: https://github.com/cakephp/cakephp/issues/2050

I can't bother to research it too much more, but disabling `ssl_verify_host` fixes the issues while still performing other SSL verification.
