### PR TITLE
Properly escape dir field

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -342,7 +342,8 @@ class UploadBehavior extends ModelBehavior {
 			if ($model->hasField($options['fields']['dir'])) {
 				if ($created && $options['pathMethod'] == '_getPathFlat') {
 				} elseif ($options['saveDir']) {
-					$temp[$model->alias][$options['fields']['dir']] = "'{$tempPath}'";
+					$db = $model->getDataSource();
+					$temp[$model->alias][$options['fields']['dir']] = $db->value($tempPath, 'string');
 				}
 			}
 		}

--- a/Test/Case/Model/Behavior/UploadTest.php
+++ b/Test/Case/Model/Behavior/UploadTest.php
@@ -244,6 +244,23 @@ class UploadBehaviorTest extends CakeTestCase {
 		$this->assertSame((string)$nextId, $this->TestUploadTwo->field('dir', array('TestUploadTwo.id' => $nextId)));
 	}
 
+	public function testSaveDirEscaped() {
+		$this->TestUpload->actsAs['Upload.Upload']['photo']['pathMethod'] = 'random';
+		$this->mockUpload(array('handleUploadedFile', 'unlink', '_getMimeType', '_createThumbnails', '_getPathRandom'));
+
+		$DS = '\\';
+		$randomPath = '01' . $DS . '02' . $DS . '03';
+
+		$this->MockUpload->expects($this->once())->method('handleUploadedFile')->will($this->returnValue(true));
+		$this->MockUpload->expects($this->once())->method('_getPathRandom')->will($this->returnValue($randomPath));
+
+		$result = $this->TestUpload->save($this->data['test_ok']);
+		$this->assertInternalType('array', $result);
+		$newRecord = $this->TestUpload->findById($this->TestUpload->id);
+
+		$this->assertSame($randomPath, $newRecord['TestUpload']['dir']);
+	}
+
 	public function testDeleteOnUpdate() {
 		$this->TestUpload->actsAs['Upload.Upload']['photo']['deleteOnUpdate'] = true;
 		$this->mockUpload();


### PR DESCRIPTION
I had some trouble using this plugin on my Windows dev machine, when having the pathMethod set to random or randomCombined. It basically uploads the files properly, and are placed in the right spot, but the 'dir' fields would not be saved correctly (missing slashes and/or zeros).

As is turns out the dir field isn't properly escaped in `UploadBehavior::afterSave`. Previous code would only wrap the field with `'`, not escape backslashes (used as DS on windows).

I'm just starting to use unit tests :sweat_smile:, so hopefully this addition update is okay.
