### PR TITLE
Issue #158 / #183 - add assertions for runtime config to unit test

### DIFF
--- a/Test/Case/Model/Behavior/UploadTest.php
+++ b/Test/Case/Model/Behavior/UploadTest.php
@@ -329,10 +329,14 @@ class UploadBehaviorTest extends CakeTestCase {
 		// We'll save the record twice using the same model instance,
 		// but handleUploadedFile should only be called once, on the first save.
 		$this->MockUpload->expects($this->once())->method('handleUploadedFile')->will($this->returnValue(true));
-		$result = $this->TestUpload->save($this->data['test_update']);
+		$this->TestUpload->save($this->data['test_update']);
+		$runtime = $this->TestUpload->Behaviors->Upload->runtime;
+		$this->assertInternalType('array', $runtime['TestUpload']['photo']);
 
 		$this->TestUpload->read(null, $this->data['test_update']['id']);
-		$result = $this->TestUpload->save(); // intentionally don't pass an uploaded file in save data
+		$this->TestUpload->save(); // intentionally don't pass an uploaded file in save data
+		$runtime = $this->TestUpload->Behaviors->Upload->runtime;
+		$this->assertFalse(isset($runtime['TestUpload']['photo']));
 	}
 
 	public function testUnlinkFileOnDelete() {


### PR DESCRIPTION
Resolves issue brought up at #183 https://github.com/josegonzalez/cakephp-upload/pull/183 regarding not checking the result.

So I don't seem like a complete idiot, the test was 'working', and failing without my changes, because it asserts that handleUploadedFile will be called once only - and before, when the runtime config was not reset between saves, handleUploadedFile would get called twice. But yeah, I should have made it more explicit, like I've done here.

Signed-off-by: Joshua Paling joshua.paling@gmail.com
