### PR TITLE
check file_exists before unlink

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -371,7 +371,10 @@ class UploadBehavior extends ModelBehavior {
 	}
 
 	public function unlink($file) {
-		return unlink($file);
+		if (file_exists($file)) {
+			return unlink($file);
+		}
+		return true;
 	}
 
 	public function deleteFolder(Model $model, $path) {


### PR DESCRIPTION
To prevent the No such file or directory Warnings, check if file exists before delete them via unlink function
