### PR TITLE
Add 'path' (relative to webroot) to 'fields' option

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -332,9 +332,6 @@ class UploadBehavior extends ModelBehavior {
 				$settingsTemp = $this->settings[$model->alias][$field];
 				$settingsTemp['path'] = $settingsTemp['dir'];
 				$dir = $this->_path($model, $field, $settingsTemp);
-				if (substr($dir, 0, 1) === DIRECTORY_SEPARATOR) {
-					$dir = substr($dir, 1);
-				}
 			}
 			$tmp = $this->runtime[$model->alias][$field]['tmp_name'];
 			$filePath = $path . $model->data[$model->alias][$field];

--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -26,7 +26,7 @@ class UploadBehavior extends ModelBehavior {
 		'rootDir' => null,
 		'pathMethod' => 'primaryKey',
 		'path' => '{ROOT}webroot{DS}files{DS}{model}{DS}{field}{DS}',
-		'fields' => array('dir' => 'dir', 'type' => 'type', 'size' => 'size'),
+		'fields' => array('dir' => 'dir', 'path' => 'path', 'type' => 'type', 'size' => 'size'),
 		'mimetypes' => array(),
 		'extensions' => array(),
 		'maxSize' => 2097152,
@@ -156,6 +156,8 @@ class UploadBehavior extends ModelBehavior {
 				)));
 			}
 
+			$options['dir'] = str_replace('{ROOT}webroot{DS}', '{DS}', $options['path']);
+
 			$options['path'] = Folder::slashTerm($this->_path($model, $field, array(
 				'isThumbnail' => false,
 				'path' => $options['path'],
@@ -243,6 +245,7 @@ class UploadBehavior extends ModelBehavior {
 						$options['fields']['type'] => null,
 						$options['fields']['size'] => null,
 						$options['fields']['dir'] => null,
+						$options['fields']['path'] => null,
 					);
 
 					$this->_removingOnly[$field] = true;
@@ -325,6 +328,10 @@ class UploadBehavior extends ModelBehavior {
 			if (!empty($tempPath)) {
 				$path .= $tempPath . DS;
 				$thumbnailPath .= $tempPath . DS;
+
+				$settingsTemp = $this->settings[$model->alias][$field];
+				$settingsTemp['path'] = $settingsTemp['dir'];
+				$dir = substr($this->_path($model, $field, $settingsTemp), 1);
 			}
 			$tmp = $this->runtime[$model->alias][$field]['tmp_name'];
 			$filePath = $path . $model->data[$model->alias][$field];
@@ -342,6 +349,12 @@ class UploadBehavior extends ModelBehavior {
 				} elseif ($options['saveDir']) {
 					$db = $model->getDataSource();
 					$temp[$model->alias][$options['fields']['dir']] = $db->value($tempPath, 'string');
+				}
+			} elseif ($model->hasField($options['fields']['path'])) {
+				if ($created && $options['pathMethod'] == '_getPathFlat') {
+				} elseif ($options['saveDir']) {
+					$db = $model->getDataSource();
+					$temp[$model->alias][$options['fields']['path']] = $db->value($dir . $tempPath . DIRECTORY_SEPARATOR, 'string');
 				}
 			}
 		}

--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -331,7 +331,10 @@ class UploadBehavior extends ModelBehavior {
 
 				$settingsTemp = $this->settings[$model->alias][$field];
 				$settingsTemp['path'] = $settingsTemp['dir'];
-				$dir = substr($this->_path($model, $field, $settingsTemp), 1);
+				$dir = $this->_path($model, $field, $settingsTemp);
+				if (substr($dir, 0, 1) === DIRECTORY_SEPARATOR) {
+					$dir = substr($dir, 1);
+				}
 			}
 			$tmp = $this->runtime[$model->alias][$field]['tmp_name'];
 			$filePath = $path . $model->data[$model->alias][$field];

--- a/README.markdown
+++ b/README.markdown
@@ -461,9 +461,10 @@ The Upload plugin also comes with a `FileImport` behavior and a `FileGrabber` be
 		* {size}: Replaced by a zero-length string (the empty string) when used for the regular file upload path. Only available for resized thumbnails.
 		* {geometry}: Replaced by a zero-length string (the empty string) when used for the regular file upload path. Only available for resized thumbnails.
 * `fields`: An array of fields to use when uploading files
-	* Default: (array) `array('dir' => 'dir', 'type' => 'type', 'size' => 'size')`
+	* Default: (array) `array('dir' => 'dir', 'path' => 'path', 'type' => 'type', 'size' => 'size')`
 	* Options:
 		* dir: Field to use for storing the directory
+		* path: Field to use for storing the path (relative to the webroot)
 		* type: Field to use for storing the filetype
 		* size: Field to use for storing the filesize
 * `rootDir`: Root directory for moving images. Auto-prepended to `path` and `thumbnailPath` where necessary


### PR DESCRIPTION
A fast manner to store and retrieve the path of the file. It’s relative to the webroot. Example:

```php
echo $this->webroot . $upload['Model']['path'] . $upload['Model']['name'];
```