### PR TITLE
Add {geometry} placeholder to 'thumbnailName' option

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -1048,8 +1048,8 @@ class UploadBehavior extends ModelBehavior {
 		}
 
 		$fileName = str_replace(
-			array('{size}', '{filename}', '{primaryKey}'),
-			array($size, $pathInfo['filename'], $model->id),
+			array('{size}', '{geometry}', '{filename}', '{primaryKey}'),
+			array($size, $geometry, $pathInfo['filename'], $model->id),
 			$this->settings[$model->alias][$field]['thumbnailName']
 		);
 
@@ -1080,8 +1080,8 @@ class UploadBehavior extends ModelBehavior {
 		}
 
 		$fileName = str_replace(
-			array('{size}', '{filename}', '{primaryKey}'),
-			array($size, $pathInfo['filename'], $model->id),
+			array('{size}', '{geometry}', '{filename}', '{primaryKey}'),
+			array($size, $geometry, $pathInfo['filename'], $model->id),
 			$this->settings[$model->alias][$field]['thumbnailName']
 		);
 
@@ -1709,8 +1709,8 @@ class UploadBehavior extends ModelBehavior {
 
 		foreach ($options['thumbnailSizes'] as $size => $geometry) {
 			$fileName = str_replace(
-				array('{size}', '{filename}', '{primaryKey}', '{time}', '{microtime}'),
-				array($size, $pathInfo['filename'], $model->id, time(), microtime()),
+				array('{size}', '{geometry}', '{filename}', '{primaryKey}', '{time}', '{microtime}'),
+				array($size, $geometry, $pathInfo['filename'], $model->id, time(), microtime()),
 				$options['thumbnailName']
 			);
 

--- a/README.markdown
+++ b/README.markdown
@@ -495,7 +495,7 @@ The Upload plugin also comes with a `FileImport` behavior and a `FileGrabber` be
 		* php: Uses the built-in PHP methods (`GD` extension) to generate thumbnails. Does not support BMP images.
 * `thumbnailName`: Naming style for a thumbnail
 	* Default: `NULL`
-	* Note: The tokens `{size}` and `{filename}` are both valid for naming and will be auto-replaced with the actual terms.
+	* Note: The tokens `{size}`, `{geometry}` and `{filename}` are valid for naming and will be auto-replaced with the actual terms.
 	* Note: As well, the extension of the file will be automatically added.
 	* Note: When left unspecified, will be set to `{size}_{filename}` or `{filename}_{size}` depending upon the value of `thumbnailPrefixStyle`
 * `thumbnailPath`: A path relative to the `rootDir` where thumbnails will be saved. Should end in `{DS}`. If not set, thumbnails will be saved at `path`.


### PR DESCRIPTION
Enables use a naming convention similar to WordPress. Example:

``` php
'thumbnailName' => '{filename}-{geometry}',
```

Will generate:

```
photo-86x86.jpg
```
