### PR TITLE
Changed assertEqual to assertEquals

### DIFF
--- a/Test/Case/Model/Behavior/UploadTest.php
+++ b/Test/Case/Model/Behavior/UploadTest.php
@@ -113,30 +113,30 @@ class UploadBehaviorTest extends CakeTestCase {
 
 	function testSetup() {
 		$this->mockUpload(array('handleUploadedFile', 'unlink'));
-		$this->assertEqual('_resizeImagick', $this->MockUpload->settings['TestUpload']['photo']['thumbnailMethod']);
-		$this->assertEqual('_getPathPrimaryKey', $this->MockUpload->settings['TestUpload']['photo']['pathMethod']);
+		$this->assertEquals('_resizeImagick', $this->MockUpload->settings['TestUpload']['photo']['thumbnailMethod']);
+		$this->assertEquals('_getPathPrimaryKey', $this->MockUpload->settings['TestUpload']['photo']['pathMethod']);
 	}
 
 	function testUploadSettings() {
 		$this->mockUpload(array('handleUploadedFile', 'unlink'));
-		$this->assertEqual('_resizeImagick', $this->MockUpload->settings['TestUpload']['photo']['thumbnailMethod']);
-		$this->assertEqual('_getPathPrimaryKey', $this->MockUpload->settings['TestUpload']['photo']['pathMethod']);
+		$this->assertEquals('_resizeImagick', $this->MockUpload->settings['TestUpload']['photo']['thumbnailMethod']);
+		$this->assertEquals('_getPathPrimaryKey', $this->MockUpload->settings['TestUpload']['photo']['pathMethod']);
 
 		$this->TestUpload->uploadSettings('photo', 'thumbnailMethod', '_resizePhp');
-		$this->assertEqual('_resizePhp', $this->MockUpload->settings['TestUpload']['photo']['thumbnailMethod']);
-		$this->assertEqual('_getPathPrimaryKey', $this->MockUpload->settings['TestUpload']['photo']['pathMethod']);
+		$this->assertEquals('_resizePhp', $this->MockUpload->settings['TestUpload']['photo']['thumbnailMethod']);
+		$this->assertEquals('_getPathPrimaryKey', $this->MockUpload->settings['TestUpload']['photo']['pathMethod']);
 
 		$this->TestUpload->uploadSettings('photo', array(
 			'thumbnailMethod' => '_resizeImagick',
 			'pathMethod' => '_getPathFlat',
 		));
-		$this->assertEqual('_resizeImagick', $this->MockUpload->settings['TestUpload']['photo']['thumbnailMethod']);
-		$this->assertEqual('_getPathFlat', $this->MockUpload->settings['TestUpload']['photo']['pathMethod']);
+		$this->assertEquals('_resizeImagick', $this->MockUpload->settings['TestUpload']['photo']['thumbnailMethod']);
+		$this->assertEquals('_getPathFlat', $this->MockUpload->settings['TestUpload']['photo']['pathMethod']);
 
 		$this->TestUpload->uploadSettings('photo', array('pathMethod', 'thumbnailQuality'), array('_getPathPrimaryKey', 100));
-		$this->assertEqual('_resizeImagick', $this->MockUpload->settings['TestUpload']['photo']['thumbnailMethod']);
-		$this->assertEqual('_getPathPrimaryKey', $this->MockUpload->settings['TestUpload']['photo']['pathMethod']);
-		$this->assertEqual(100, $this->MockUpload->settings['TestUpload']['photo']['thumbnailQuality']);
+		$this->assertEquals('_resizeImagick', $this->MockUpload->settings['TestUpload']['photo']['thumbnailMethod']);
+		$this->assertEquals('_getPathPrimaryKey', $this->MockUpload->settings['TestUpload']['photo']['pathMethod']);
+		$this->assertEquals(100, $this->MockUpload->settings['TestUpload']['photo']['thumbnailQuality']);
 	}
 
 	function testFileSize() {
@@ -145,7 +145,7 @@ class UploadBehaviorTest extends CakeTestCase {
 		$result = $this->TestUpload->save($this->data['test_ok']);
 		$this->assertInternalType('array', $result);
 		$newRecord = $this->TestUpload->findById($this->TestUpload->id);
-		$this->assertEqual($this->data['test_ok']['photo']['size'], $newRecord['TestUpload']['size']);
+		$this->assertEquals($this->data['test_ok']['photo']['size'], $newRecord['TestUpload']['size']);
 	}
 
 	function testSimpleUpload() {
@@ -172,7 +172,7 @@ class UploadBehaviorTest extends CakeTestCase {
 			)
 		);
 
-		$this->assertEqual($expectedRecord, $newRecord);
+		$this->assertEquals($expectedRecord, $newRecord);
 	}
 
 	/**
@@ -256,7 +256,7 @@ class UploadBehaviorTest extends CakeTestCase {
 		$result = $this->TestUpload->save($this->data['test_update_other_field']);
 		$this->assertInternalType('array', $result);
 		$newRecord = $this->TestUpload->findById($this->TestUpload->id);
-		$this->assertEqual($this->data['test_update_other_field']['other_field'], $newRecord['TestUpload']['other_field']);
+		$this->assertEquals($this->data['test_update_other_field']['other_field'], $newRecord['TestUpload']['other_field']);
 	}
 
 	function testUpdateWithoutNewUpload() {
@@ -266,7 +266,7 @@ class UploadBehaviorTest extends CakeTestCase {
 		$result = $this->TestUpload->save($this->data['test_update_other_field']);
 		$this->assertInternalType('array', $result);
 		$newRecord = $this->TestUpload->findById($this->TestUpload->id);
-		$this->assertEqual($this->data['test_update_other_field']['other_field'], $newRecord['TestUpload']['other_field']);
+		$this->assertEquals($this->data['test_update_other_field']['other_field'], $newRecord['TestUpload']['other_field']);
 	}
 
 	function testUpdateWithoutNewUploadWithoutFieldSet() {
@@ -276,7 +276,7 @@ class UploadBehaviorTest extends CakeTestCase {
 		$result = $this->TestUpload->save($this->data['test_update_other_field_without_photo_set']);
 		$this->assertInternalType('array', $result);
 		$newRecord = $this->TestUpload->findById($this->TestUpload->id);
-		$this->assertEqual($this->data['test_update_other_field_without_photo_set']['other_field'], $newRecord['TestUpload']['other_field']);
+		$this->assertEquals($this->data['test_update_other_field_without_photo_set']['other_field'], $newRecord['TestUpload']['other_field']);
 	}
 
 	function testUnlinkFileOnDelete() {
@@ -372,16 +372,16 @@ class UploadBehaviorTest extends CakeTestCase {
 		);
 		$this->TestUpload->set($data);
 		$this->assertFalse($this->TestUpload->validates());
-		$this->assertEqual(1, count($this->TestUpload->validationErrors));
-		$this->assertEqual('isUnderPhpSizeLimit', current($this->TestUpload->validationErrors['photo']));
+		$this->assertEquals(1, count($this->TestUpload->validationErrors));
+		$this->assertEquals('isUnderPhpSizeLimit', current($this->TestUpload->validationErrors['photo']));
 
 		$this->TestUpload->set($this->data['test_ok']);
 		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->assertEquals(0, count($this->TestUpload->validationErrors));
 
 		$this->TestUpload->set($this->data['test_remove']);
 		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->assertEquals(0, count($this->TestUpload->validationErrors));
 	}
 
 	function testIsUnderFormSizeLimit() {
@@ -405,16 +405,16 @@ class UploadBehaviorTest extends CakeTestCase {
 		);
 		$this->TestUpload->set($data);
 		$this->assertFalse($this->TestUpload->validates());
-		$this->assertEqual(1, count($this->TestUpload->validationErrors));
-		$this->assertEqual('isUnderFormSizeLimit', current($this->TestUpload->validationErrors['photo']));
+		$this->assertEquals(1, count($this->TestUpload->validationErrors));
+		$this->assertEquals('isUnderFormSizeLimit', current($this->TestUpload->validationErrors['photo']));
 
 		$this->TestUpload->set($this->data['test_ok']);
 		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->assertEquals(0, count($this->TestUpload->validationErrors));
 
 		$this->TestUpload->set($this->data['test_remove']);
 		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->assertEquals(0, count($this->TestUpload->validationErrors));
 	}
 
 	function testIsCompletedUpload() {
@@ -438,16 +438,16 @@ class UploadBehaviorTest extends CakeTestCase {
 		);
 		$this->TestUpload->set($data);
 		$this->assertFalse($this->TestUpload->validates());
-		$this->assertEqual(1, count($this->TestUpload->validationErrors));
-		$this->assertEqual('isCompletedUpload', current($this->TestUpload->validationErrors['photo']));
+		$this->assertEquals(1, count($this->TestUpload->validationErrors));
+		$this->assertEquals('isCompletedUpload', current($this->TestUpload->validationErrors['photo']));
 
 		$this->TestUpload->set($this->data['test_ok']);
 		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->assertEquals(0, count($this->TestUpload->validationErrors));
 
 		$this->TestUpload->set($this->data['test_remove']);
 		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->assertEquals(0, count($this->TestUpload->validationErrors));
 	}
 
 	function testIsFileUpload() {
@@ -471,16 +471,16 @@ class UploadBehaviorTest extends CakeTestCase {
 		);
 		$this->TestUpload->set($data);
 		$this->assertFalse($this->TestUpload->validates());
-		$this->assertEqual(1, count($this->TestUpload->validationErrors));
-		$this->assertEqual('isFileUpload', current($this->TestUpload->validationErrors['photo']));
+		$this->assertEquals(1, count($this->TestUpload->validationErrors));
+		$this->assertEquals('isFileUpload', current($this->TestUpload->validationErrors['photo']));
 
 		$this->TestUpload->set($this->data['test_ok']);
 		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->assertEquals(0, count($this->TestUpload->validationErrors));
 
 		$this->TestUpload->set($this->data['test_remove']);
 		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->assertEquals(0, count($this->TestUpload->validationErrors));
 	}
 
 	function testTempDirExists() {
@@ -504,16 +504,16 @@ class UploadBehaviorTest extends CakeTestCase {
 		);
 		$this->TestUpload->set($data);
 		$this->assertFalse($this->TestUpload->validates());
-		$this->assertEqual(1, count($this->TestUpload->validationErrors));
-		$this->assertEqual('tempDirExists', current($this->TestUpload->validationErrors['photo']));
+		$this->assertEquals(1, count($this->TestUpload->validationErrors));
+		$this->assertEquals('tempDirExists', current($this->TestUpload->validationErrors['photo']));
 
 		$this->TestUpload->set($this->data['test_ok']);
 		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->assertEquals(0, count($this->TestUpload->validationErrors));
 
 		$this->TestUpload->set($this->data['test_remove']);
 		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->assertEquals(0, count($this->TestUpload->validationErrors));
 	}
 
 	function testIsSuccessfulWrite() {
@@ -537,16 +537,16 @@ class UploadBehaviorTest extends CakeTestCase {
 		);
 		$this->TestUpload->set($data);
 		$this->assertFalse($this->TestUpload->validates());
-		$this->assertEqual(1, count($this->TestUpload->validationErrors));
-		$this->assertEqual('isSuccessfulWrite', current($this->TestUpload->validationErrors['photo']));
+		$this->assertEquals(1, count($this->TestUpload->validationErrors));
+		$this->assertEquals('isSuccessfulWrite', current($this->TestUpload->validationErrors['photo']));
 
 		$this->TestUpload->set($this->data['test_ok']);
 		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->assertEquals(0, count($this->TestUpload->validationErrors));
 
 		$this->TestUpload->set($this->data['test_remove']);
 		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->assertEquals(0, count($this->TestUpload->validationErrors));
 	}
 
 	function testNoPhpExtensionErrors() {
@@ -570,16 +570,16 @@ class UploadBehaviorTest extends CakeTestCase {
 		);
 		$this->TestUpload->set($data);
 		$this->assertFalse($this->TestUpload->validates());
-		$this->assertEqual(1, count($this->TestUpload->validationErrors));
-		$this->assertEqual('noPhpExtensionErrors', current($this->TestUpload->validationErrors['photo']));
+		$this->assertEquals(1, count($this->TestUpload->validationErrors));
+		$this->assertEquals('noPhpExtensionErrors', current($this->TestUpload->validationErrors['photo']));
 
 		$this->TestUpload->set($this->data['test_ok']);
 		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->assertEquals(0, count($this->TestUpload->validationErrors));
 
 		$this->TestUpload->set($this->data['test_remove']);
 		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->assertEquals(0, count($this->TestUpload->validationErrors));
 	}
 
 	function testIsValidMimeType() {
@@ -601,8 +601,8 @@ class UploadBehaviorTest extends CakeTestCase {
 
 		$this->TestUpload->set($this->data['test_ok']);
 		$this->assertFalse($this->TestUpload->validates());
-		$this->assertEqual(1, count($this->TestUpload->validationErrors));
-		$this->assertEqual('isValidMimeType', current($this->TestUpload->validationErrors['photo']));
+		$this->assertEquals(1, count($this->TestUpload->validationErrors));
+		$this->assertEquals('isValidMimeType', current($this->TestUpload->validationErrors['photo']));
 
 		$this->TestUpload->Behaviors->detach('Upload.Upload');
 		$this->TestUpload->Behaviors->attach('Upload.Upload', array(
@@ -613,11 +613,11 @@ class UploadBehaviorTest extends CakeTestCase {
 
 		$this->TestUpload->set($this->data['test_ok']);
 		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->assertEquals(0, count($this->TestUpload->validationErrors));
 
 		$this->TestUpload->set($this->data['test_remove']);
 		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->assertEquals(0, count($this->TestUpload->validationErrors));
 
 		$this->TestUpload->validate = array(
 			'photo' => array(
@@ -630,7 +630,7 @@ class UploadBehaviorTest extends CakeTestCase {
 
 		$this->TestUpload->set($this->data['test_ok']);
 		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->assertEquals(0, count($this->TestUpload->validationErrors));
 	}
 
 	function testIsValidExtension() {
@@ -652,14 +652,14 @@ class UploadBehaviorTest extends CakeTestCase {
 
 		$this->TestUpload->set($this->data['test_ok']);
 		$this->assertFalse($this->TestUpload->validates());
-		$this->assertEqual(1, count($this->TestUpload->validationErrors));
-		$this->assertEqual('isValidExtension', current($this->TestUpload->validationErrors['photo']));
+		$this->assertEquals(1, count($this->TestUpload->validationErrors));
+		$this->assertEquals('isValidExtension', current($this->TestUpload->validationErrors['photo']));
 
 		$data = $this->data['test_ok'];
 		$data['photo']['name'] = 'Photo.bmp';
 		$this->TestUpload->set($data);
 		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->assertEquals(0, count($this->TestUpload->validationErrors));
 
 		$this->TestUpload->Behaviors->detach('Upload.Upload');
 		$this->TestUpload->Behaviors->attach('Upload.Upload', array(
@@ -669,25 +669,25 @@ class UploadBehaviorTest extends CakeTestCase {
 		$this->TestUpload->validate['photo']['isValidExtension']['rule'] = array('isValidExtension', 'jpg');
 		$this->TestUpload->set($this->data['test_ok']);
 		$this->assertFalse($this->TestUpload->validates());
-		$this->assertEqual(1, count($this->TestUpload->validationErrors));
-		$this->assertEqual('isValidExtension', current($this->TestUpload->validationErrors['photo']));
+		$this->assertEquals(1, count($this->TestUpload->validationErrors));
+		$this->assertEquals('isValidExtension', current($this->TestUpload->validationErrors['photo']));
 
 		$this->TestUpload->validate['photo']['isValidExtension']['rule'] = array('isValidExtension', array('jpg'));
 		$this->TestUpload->set($this->data['test_ok']);
 		$this->assertFalse($this->TestUpload->validates());
-		$this->assertEqual(1, count($this->TestUpload->validationErrors));
-		$this->assertEqual('isValidExtension', current($this->TestUpload->validationErrors['photo']));
+		$this->assertEquals(1, count($this->TestUpload->validationErrors));
+		$this->assertEquals('isValidExtension', current($this->TestUpload->validationErrors['photo']));
 
 		$this->TestUpload->validate['photo']['isValidExtension']['rule'] = array('isValidExtension', array('jpg', 'bmp'));
 		$this->TestUpload->set($this->data['test_ok']);
 		$this->assertFalse($this->TestUpload->validates());
-		$this->assertEqual(1, count($this->TestUpload->validationErrors));
-		$this->assertEqual('isValidExtension', current($this->TestUpload->validationErrors['photo']));
+		$this->assertEquals(1, count($this->TestUpload->validationErrors));
+		$this->assertEquals('isValidExtension', current($this->TestUpload->validationErrors['photo']));
 
 		$this->TestUpload->validate['photo']['isValidExtension']['rule'] = array('isValidExtension', array('jpg', 'bmp', 'png'));
 		$this->TestUpload->set($this->data['test_ok']);
 		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->assertEquals(0, count($this->TestUpload->validationErrors));
 
 		$this->TestUpload->validate = array(
 			'photo' => array(
@@ -704,18 +704,18 @@ class UploadBehaviorTest extends CakeTestCase {
 
 		$this->TestUpload->set($this->data['test_ok']);
 		$this->assertFalse($this->TestUpload->validates());
-		$this->assertEqual(1, count($this->TestUpload->validationErrors));
-		$this->assertEqual('isValidExtension', current($this->TestUpload->validationErrors['photo']));
+		$this->assertEquals(1, count($this->TestUpload->validationErrors));
+		$this->assertEquals('isValidExtension', current($this->TestUpload->validationErrors['photo']));
 
 		$data['photo']['name'] = 'Photo.jpg';
 		$this->TestUpload->set($this->data['test_ok']);
 		$this->assertFalse($this->TestUpload->validates());
-		$this->assertEqual(1, count($this->TestUpload->validationErrors));
-		$this->assertEqual('isValidExtension', current($this->TestUpload->validationErrors['photo']));
+		$this->assertEquals(1, count($this->TestUpload->validationErrors));
+		$this->assertEquals('isValidExtension', current($this->TestUpload->validationErrors['photo']));
 
 		$this->TestUpload->set($this->data['test_remove']);
 		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->assertEquals(0, count($this->TestUpload->validationErrors));
 	}
 
 	function testIsWritable() {
@@ -731,8 +731,8 @@ class UploadBehaviorTest extends CakeTestCase {
 		$this->TestUpload->set($this->data['test_ok']);
 		$this->assertFalse($this->TestUpload->validates());
 
-		$this->assertEqual(1, count($this->TestUpload->validationErrors));
-		$this->assertEqual('isWritable', current($this->TestUpload->validationErrors['photo']));
+		$this->assertEquals(1, count($this->TestUpload->validationErrors));
+		$this->assertEquals('isWritable', current($this->TestUpload->validationErrors['photo']));
 
 		$this->TestUpload->Behaviors->detach('Upload.Upload');
 		$this->TestUpload->Behaviors->attach('Upload.Upload', array(
@@ -752,11 +752,11 @@ class UploadBehaviorTest extends CakeTestCase {
 		);
 		$this->TestUpload->set($data);
 		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->assertEquals(0, count($this->TestUpload->validationErrors));
 
 		$this->TestUpload->set($this->data['test_remove']);
 		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->assertEquals(0, count($this->TestUpload->validationErrors));
 	}
 
 	function testIsValidDir() {
@@ -772,8 +772,8 @@ class UploadBehaviorTest extends CakeTestCase {
 		$this->TestUpload->set($this->data['test_ok']);
 		$this->assertFalse($this->TestUpload->validates());
 
-		$this->assertEqual(1, count($this->TestUpload->validationErrors));
-		$this->assertEqual('isValidDir', current($this->TestUpload->validationErrors['photo']));
+		$this->assertEquals(1, count($this->TestUpload->validationErrors));
+		$this->assertEquals('isValidDir', current($this->TestUpload->validationErrors['photo']));
 
 		$this->TestUpload->Behaviors->detach('Upload.Upload');
 		$this->TestUpload->Behaviors->attach('Upload.Upload', array(
@@ -793,11 +793,11 @@ class UploadBehaviorTest extends CakeTestCase {
 		);
 		$this->TestUpload->set($data);
 		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->assertEquals(0, count($this->TestUpload->validationErrors));
 
 		$this->TestUpload->set($this->data['test_remove']);
 		$this->assertTrue($this->TestUpload->validates());
-		$this->assertEqual(0, count($this->TestUpload->validationErrors));
+		$this->assertEquals(0, count($this->TestUpload->validationErrors));
 	}
 
 	function testIsImage() {
@@ -844,7 +844,7 @@ class UploadBehaviorTest extends CakeTestCase {
 		$result = $this->TestUpload->Behaviors->Upload->_getPathFlat($this->TestUpload, 'photo', TMP . $basePath);
 
 		$this->assertInternalType('string', $result);
-		$this->assertEqual(0, strlen($result));
+		$this->assertEquals(0, strlen($result));
 	}
 
 	function testGetPathPrimaryKey() {
@@ -853,8 +853,8 @@ class UploadBehaviorTest extends CakeTestCase {
 		$result = $this->TestUpload->Behaviors->Upload->_getPathPrimaryKey($this->TestUpload, 'photo', TMP . $basePath);
 
 		$this->assertInternalType('integer', $result);
-		$this->assertEqual(1, strlen($result));
-		$this->assertEqual($result, $this->TestUpload->id);
+		$this->assertEquals(1, strlen($result));
+		$this->assertEquals($result, $this->TestUpload->id);
 		$this->assertTrue(is_dir(TMP . $basePath . $result));
 	}
 
@@ -863,7 +863,7 @@ class UploadBehaviorTest extends CakeTestCase {
 		$result = $this->TestUpload->Behaviors->Upload->_getPathRandom($this->TestUpload, 'photo', TMP . $basePath);
 
 		$this->assertInternalType('string', $result);
-		$this->assertEqual(8, strlen($result));
+		$this->assertEquals(8, strlen($result));
 		$this->assertTrue(is_dir(TMP . $basePath . $result));
 	}
 
@@ -873,14 +873,14 @@ class UploadBehaviorTest extends CakeTestCase {
 		));
 
 		$this->assertInternalType('string', $result);
-		$this->assertEqual(WWW_ROOT . 'files' . DIRECTORY_SEPARATOR . 'test_upload' . DIRECTORY_SEPARATOR . 'photo' . DIRECTORY_SEPARATOR, $result);
+		$this->assertEquals(WWW_ROOT . 'files' . DIRECTORY_SEPARATOR . 'test_upload' . DIRECTORY_SEPARATOR . 'photo' . DIRECTORY_SEPARATOR, $result);
 
 		$result = $this->TestUpload->Behaviors->Upload->_path($this->TestUpload, 'photo', array(
 			'path' => 'webroot{DS}files//{size}/{model}\\{field}{DS}{geometry}///',
 		));
 
 		$this->assertInternalType('string', $result);
-		$this->assertEqual(WWW_ROOT . 'files' . DIRECTORY_SEPARATOR . '{size}' . DIRECTORY_SEPARATOR . 'test_upload' . DIRECTORY_SEPARATOR . 'photo' . DIRECTORY_SEPARATOR . '{geometry}' . DIRECTORY_SEPARATOR, $result);
+		$this->assertEquals(WWW_ROOT . 'files' . DIRECTORY_SEPARATOR . '{size}' . DIRECTORY_SEPARATOR . 'test_upload' . DIRECTORY_SEPARATOR . 'photo' . DIRECTORY_SEPARATOR . '{geometry}' . DIRECTORY_SEPARATOR, $result);
 
 
 		$result = $this->TestUpload->Behaviors->Upload->_path($this->TestUpload, 'photo', array(
@@ -889,7 +889,7 @@ class UploadBehaviorTest extends CakeTestCase {
 		));
 
 		$this->assertInternalType('string', $result);
-		$this->assertEqual(WWW_ROOT . 'files' . DIRECTORY_SEPARATOR . 'test_upload' . DIRECTORY_SEPARATOR . 'photo' . DIRECTORY_SEPARATOR, $result);
+		$this->assertEquals(WWW_ROOT . 'files' . DIRECTORY_SEPARATOR . 'test_upload' . DIRECTORY_SEPARATOR . 'photo' . DIRECTORY_SEPARATOR, $result);
 	}
 
 	function testPrepareFilesForDeletion() {
@@ -915,8 +915,8 @@ class UploadBehaviorTest extends CakeTestCase {
 		);
 
 		$this->assertInternalType('array', $result);
-		$this->assertEqual(1,count($result));
-		$this->assertEqual(4, count($result['TestUpload']));
+		$this->assertEquals(1,count($result));
+		$this->assertEquals(4, count($result['TestUpload']));
 	}
 
 	function testPrepareFilesForDeletionWithThumbnailType() {
@@ -943,8 +943,8 @@ class UploadBehaviorTest extends CakeTestCase {
 		);
 
 		$this->assertInternalType('array', $result);
-		$this->assertEqual(1,count($result));
-		$this->assertEqual(4, count($result['TestUpload']));
+		$this->assertEquals(1,count($result));
+		$this->assertEquals(4, count($result['TestUpload']));
 	}
 
 	function testPrepareFilesForDeletionWithMediaFileAndFalseThumbnailType() {
@@ -971,8 +971,8 @@ class UploadBehaviorTest extends CakeTestCase {
 		);
 
 		$this->assertInternalType('array', $result);
-		$this->assertEqual(1,count($result));
-		$this->assertEqual(4, count($result['TestUpload']));
+		$this->assertEquals(1,count($result));
+		$this->assertEquals(4, count($result['TestUpload']));
 	}
 
 	function testPrepareFilesForDeletionWithMediaFile() {
@@ -998,8 +998,8 @@ class UploadBehaviorTest extends CakeTestCase {
 		);
 
 		$this->assertInternalType('array', $result);
-		$this->assertEqual(1,count($result));
-		$this->assertEqual(4, count($result['TestUpload']));
+		$this->assertEquals(1,count($result));
+		$this->assertEquals(4, count($result['TestUpload']));
 	}
 
 }


### PR DESCRIPTION
Changed the SimpleTest backward compatible assertEqual assertions to PHPUnits assertEquals.

http://simpletest.org/api/SimpleTest/UnitTester/UnitTestCase.html#assertEqual
http://phpunit.de/manual/current/en/appendixes.assertions.html#appendixes.assertions.assertEquals

It seems the tests already adhered to the parameter order of the assertEquals method signature:
assertEquals(mixed $expected, mixed $actual[, string $message = ''])

All other used assertion methods are part of the PHPUnit framework:
assertTrue
assertFalse
assertEmpty
assertSame
assertInternalType
http://phpunit.de/manual/current/en/appendixes.assertions.html#appendixes.assertions.assertInternalType
