### PR TITLE
Added empty check for actual model data

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -317,6 +317,10 @@ class UploadBehavior extends ModelBehavior {
 			if (isset($this->_removingOnly[$field])) {
 				continue;
 			}
+			
+			if (isset($model->data[$model->alias][$field]) && empty($model->data[$model->alias][$field])) {
+				continue;
+			}
 
 			$tempPath = $this->_getPath($model, $field);
 


### PR DESCRIPTION
The runtime used has a simple empty array of the file, which still gets processed, because the empty array file isn't 'technically' empty.

The same happens if the $field is actually an empty string, aka doesn't contain any proper data.

In my case I had to over-write the $field array, when certain conditions were met. This caused an empty rename to be triggered, thus the need for the above check.
