### PR TITLE
Update UploadBehavior.php

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -1499,7 +1499,7 @@ class UploadBehavior extends ModelBehavior {
 		$image = imagecreatefromjpeg($filename);
 		$exif = false;
 		if (function_exists('exif_read_data')) {
-			$exif = exif_read_data($filename);
+			$exif = @exif_read_data($filename);
 		}
 
 		if ($image && $exif && isset($exif['Orientation'])) {


### PR DESCRIPTION
When trying to upload an image with incorrect exif data this method will throw a warning. This is because it also validates the Exif data against the spec to make sure it's valid.

> exif_read_data() also validates EXIF data tags according to the EXIF specification (» http://exif.org/Exif2-2.PDF, page 20).

You'll get this warning.

> Warning (2): exif_read_data(main_vienna_6.jpg): Incorrect APP1 Exif Identifier Code [APP/Plugin/Upload/Model/Behavior/UploadBehavior.php, line 1502]

Images with invalid exif information are still uploaded though, so it doesn't have any functional impact. However if devs are logging errors this will fill up an error log pretty quickly.