### PR TITLE
Function change to allow unset arrays

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -1984,7 +1984,7 @@ class UploadBehavior extends ModelBehavior {
 			return array();
 		}
 
-		if (!strlen($data[$model->alias][$field])) {
+		if (empty($data[$model->alias][$field])) {
 			return $this->__filesToRemove;
 		}
 


### PR DESCRIPTION
Changed a strlen for an empty to prevent a warning which can be thrown if the array dimension doesn't exist