### PR TITLE
installation - remove Bad Apostrophe

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -17,7 +17,7 @@ and copy the json snippet for the latest version into your project's
         }
     }
 
-This plugin has the type ``cakephp-plugin`` set in it's own
+This plugin has the type ``cakephp-plugin`` set in its own
 ``composer.json``, composer knows to install it inside your ``/Plugins``
 directory, rather than in the usual vendors file. It is recommended that
 you add ``/Plugins/Upload`` to your .gitignore file. (Why? `read


### PR DESCRIPTION
A possessive belonging to an "it" doesn't need an apostrophe. Don't believe me? Ask [the Oatmeal](http://theoatmeal.com/comics/apostrophe) (look for the velociraptor)!