### PR TITLE
Prevent from erasing $_config that's been set in the constructor.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
         "league/flysystem": "*"
     },
     "require-dev": {
-        "cakephp/cakephp": "3.0.*-dev",
         "phpunit/phpunit": "4.1.*",
         "league/flysystem-vfs": "*"
     },

--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -26,7 +26,6 @@ class UploadBehavior extends Behavior
      */
     public function initialize(array $config)
     {
-        $this->_config = [];
         $this->config(Hash::normalize($config));
 
         Type::map('upload.file', 'Josegonzalez\Upload\Database\Type\FileType');


### PR DESCRIPTION
The variable is already initialized in [InstanceConfigTrait](https://github.com/cakephp/cakephp/blob/master/src%2FCore%2FInstanceConfigTrait.php#L33).
