### PR TITLE
Insert the detail that the version 1.3.0, requires> = 5.4.0 PHP minimum in Composer.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/josegonzalez/cakephp-upload.png?branch=master)](https://travis-ci.org/josegonzalez/cakephp-upload) [![Coverage Status](https://coveralls.io/repos/josegonzalez/cakephp-upload/badge.png?branch=master)](https://coveralls.io/r/josegonzalez/cakephp-upload?branch=master) [![Total Downloads](https://poser.pugx.org/josegonzalez/cakephp-upload/d/total.png)](https://packagist.org/packages/josegonzalez/cakephp-upload) [![Latest Stable Version](https://poser.pugx.org/josegonzalez/cakephp-upload/v/stable.png)](https://packagist.org/packages/josegonzalez/cakephp-upload)
 
-# Upload Plugin 2.0
+# Upload Plugin 2.0 (v.1.3)
 
 The Upload Plugin is an attempt to sanely upload files using techniques garnered from packages such as [MeioUpload](http://github.com/jrbasso/MeioUpload) , [UploadPack](http://github.com/szajbus/cakephp-uploadpack) and [PHP documentation](http://php.net/manual/en/features.file-upload.php).
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Media Plugin is too complicated, and it was a PITA to merge the latest updates i
 
 * CakePHP 2.x
 * Imagick/GD PHP Extension (for thumbnail creation)
-* PHP 5
+* PHP >= 5.4.0
 * Patience
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/josegonzalez/cakephp-upload.png?branch=master)](https://travis-ci.org/josegonzalez/cakephp-upload) [![Coverage Status](https://coveralls.io/repos/josegonzalez/cakephp-upload/badge.png?branch=master)](https://coveralls.io/r/josegonzalez/cakephp-upload?branch=master) [![Total Downloads](https://poser.pugx.org/josegonzalez/cakephp-upload/d/total.png)](https://packagist.org/packages/josegonzalez/cakephp-upload) [![Latest Stable Version](https://poser.pugx.org/josegonzalez/cakephp-upload/v/stable.png)](https://packagist.org/packages/josegonzalez/cakephp-upload)
 
-# Upload Plugin 2.0 (v.1.3)
+# Upload Plugin 2.0 (v.1.3.0)
 
 The Upload Plugin is an attempt to sanely upload files using techniques garnered from packages such as [MeioUpload](http://github.com/jrbasso/MeioUpload) , [UploadPack](http://github.com/szajbus/cakephp-uploadpack) and [PHP documentation](http://php.net/manual/en/features.file-upload.php).
 

--- a/composer.json
+++ b/composer.json
@@ -136,6 +136,11 @@
       "name": "ceallred",
       "role": "Contributor",
       "homepage": "https://github.com/ceallred"
+    },
+    {
+      "name": "Sergio of EOM Design Group",
+      "role": "Contributor",
+      "homepage": "https://github.com/e-om"
     }
   ],
   "require": {

--- a/composer.json
+++ b/composer.json
@@ -140,8 +140,8 @@
   ],
   "require": {
     "composer/installers": "*",
-    "php": ">=5.3.0",
-		"ext-gd": "*",
+    "php": ">=5.4.0",
+    "ext-gd": "*",
   },
   "support": {
     "email": "cakephp+upload@josediazgonzalez.com",

--- a/composer.json
+++ b/composer.json
@@ -139,7 +139,9 @@
     }
   ],
   "require": {
-    "composer/installers": "*"
+    "composer/installers": "*",
+    "php": ">=5.3.0",
+		"ext-gd": "*",
   },
   "support": {
     "email": "cakephp+upload@josediazgonzalez.com",


### PR DESCRIPTION
Insert the detail that the version 1.3.0, requires> = 5.4.0 PHP minimum. In the short array syntax you have this version and supports PHP 5.4 and up.
Example: ['bal', 'bla ..']
Greetings and hope have been of help. ;)