### PR TITLE
Always use correct ratio when resizing an image in 'banding' mode using GD

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -1443,11 +1443,7 @@ class UploadBehavior extends ModelBehavior {
 				$resizeH = $srcH * $ratio;
 			} elseif ($resizeMode == 'band') {
 				// "banding" mode
-				if ($srcW > $srcH) {
-					$ratio = $destW / $srcW;
-				} else {
-					$ratio = $destH / $srcH;
-				}
+				$ratio = min($destW / $srcW, $destH / $srcH);
 				$resizeW = $srcW * $ratio;
 				$resizeH = $srcH * $ratio;
 			} else {


### PR DESCRIPTION
I have noticed that the resize ratio for images is not always calculated correctly when using GD as the thumbnail method and using the 'banding' method (resize to fit, add white space).
Depending on the width and heights of the source and destination images the smallest ratio is not always chosen.

For example, when a 110x50 image needs to be resized to 100x10, the ratio gets calculated based on the width difference, not the height difference. This yields ~0.9 instead of 0.2, causing the image to get too big.

I changed the calculation by taking both the horizontal and vertical ratios and picking the smallest. Let me know what you think.

It looks like the ImageMagick method already did this correctly.