### PR TITLE
Fixed the ambigous field error

### DIFF
--- a/Console/Command/ThumbnailShell.php
+++ b/Console/Command/ThumbnailShell.php
@@ -65,7 +65,7 @@ class ThumbnailShell extends AppShell {
 			$files = $this->{$modelName}->find('all', array(
 				'fields' => [$this->{$modelName}->primaryKey, $field, $mergedConfig['fields']['dir']],
 				'conditions' => array(
-					$field . " IS NOT NULL"
+					$modelName . '.' . $field . " IS NOT NULL"
 				)
 			));
 


### PR DESCRIPTION
When trying to regenerate thumbnails for models which share a field, you'll hit an ambiguous field error.