### PR TITLE
Cast null settings to empty array so Hash::get works as expected

### DIFF
--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -74,6 +74,7 @@ class UploadBehavior extends Behavior
                 continue;
             }
 
+            $settings = ($settings === null) ? [] : $settings;
             $data = $entity->get($field);
             $path = $this->getPathProcessor($entity, $data, $field, $settings);
             $basepath = $path->basepath();


### PR DESCRIPTION
Hey,

The upload blows up with an InvalidArgumentException when I have the following set in the table

`$this->addBehavior('Josegonzalez/Upload.Upload', ['file']);`

because $settings gets passed as null and Hash::get doesn't handle it properly. It works find when I do

`$this->addBehavior('Josegonzalez/Upload.Upload', ['file' => []]);`

but I think it's better to handle it here.