### PR TITLE
Fix double directory separator in constructFiles when following docs

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -19,7 +19,7 @@ passed in under each field in your behavior configuration.
     - Default: (string)
       ``Josegonzalez\Upload\File\Transformer\DefaultTransformer``
 
--  ``path``: A path relative to the ``filesystem.root``. Should end in ``{DS}``
+-  ``path``: A path relative to the ``filesystem.root``.
 
    -  Default: (string)
       ``'webroot{DS}files{DS}{model}{DS}{field}{DS}'``

--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -203,6 +203,7 @@ class UploadBehavior extends Behavior
      */
     public function constructFiles(Entity $entity, $data, $field, $settings, $basepath)
     {
+        $basepath = (substr($basepath, -1) == DS ? $basepath : $basepath . DS);
         $default = 'Josegonzalez\Upload\File\Transformer\DefaultTransformer';
         $transformerClass = Hash::get($settings, 'transformer', $default);
         $results = [];
@@ -210,12 +211,12 @@ class UploadBehavior extends Behavior
             $transformer = new $transformerClass($this->_table, $entity, $data, $field, $settings);
             $results = $transformer->transform();
             foreach ($results as $key => $value) {
-                $results[$key] = $basepath . '/' . $value;
+                $results[$key] = $basepath . $value;
             }
         } elseif (is_callable($transformerClass)) {
             $results = $transformerClass($this->_table, $entity, $data, $field, $settings);
             foreach ($results as $key => $value) {
-                $results[$key] = $basepath . '/' . $value;
+                $results[$key] = $basepath . $value;
             }
         } else {
             throw new UnexpectedValueException(sprintf(

--- a/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
@@ -309,6 +309,27 @@ class UploadBehaviorTest extends TestCase
         $this->assertEquals(['path/to/file/on/disk' => 'some/path/file.txt'], $files);
     }
 
+    public function testConstructFilesWithBasePathEndingDS()
+    {
+        $files = $this->behavior->constructFiles(
+            $this->entity,
+            ['tmp_name' => 'path/to/file/on/disk', 'name' => 'file.txt'],
+            'field',
+            [],
+            'path/'
+        );
+        $this->assertEquals(['path/to/file/on/disk' => 'path/file.txt'], $files);
+
+        $files = $this->behavior->constructFiles(
+            $this->entity,
+            ['tmp_name' => 'path/to/file/on/disk', 'name' => 'file.txt'],
+            'field',
+            [],
+            'some/path/'
+        );
+        $this->assertEquals(['path/to/file/on/disk' => 'some/path/file.txt'], $files);
+    }
+
     public function testConstructFilesWithCallable()
     {
         $callable = function () {
@@ -320,6 +341,21 @@ class UploadBehaviorTest extends TestCase
             'field',
             ['transformer' => $callable],
             'some/path'
+        );
+        $this->assertEquals(['path/to/callable/file/on/disk' => 'some/path/file.text'], $files);
+    }
+
+    public function testConstructFilesWithCallableAndBasePathEndingDS()
+    {
+        $callable = function () {
+            return ['path/to/callable/file/on/disk' => 'file.text'];
+        };
+        $files = $this->behavior->constructFiles(
+            $this->entity,
+            ['tmp_name' => 'path/to/file/on/disk', 'name' => 'file.txt'],
+            'field',
+            ['transformer' => $callable],
+            'some/path/'
         );
         $this->assertEquals(['path/to/callable/file/on/disk' => 'some/path/file.text'], $files);
     }


### PR DESCRIPTION
Contradiction between code and docs:
Doc says `path` should end with `{DS}` but the code appends a forward slash to any path when constructing files.

This results in a double `DS` on *nix systems: `webroot\files\test\\file.txt` and something ugly as `webroot\files\test/file.txt` on windows systems.