### PR TITLE
fixing default basepath to contain primaryKey

### DIFF
--- a/src/File/Path/Basepath/DefaultTrait.php
+++ b/src/File/Path/Basepath/DefaultTrait.php
@@ -16,7 +16,7 @@ trait DefaultTrait
      */
     public function basepath()
     {
-        $defaultPath = 'webroot{DS}files{DS}{model}{DS}{field}{DS}';
+        $defaultPath = 'webroot{DS}files{DS}{model}{DS}{field}{DS}{primaryKey}';
         $path = Hash::get($this->settings, 'path', $defaultPath);
         if (strpos($path, '{primaryKey}') !== false) {
             if ($this->entity->isNew()) {

--- a/tests/TestCase/File/Path/Basepath/DefaultTraitTest.php
+++ b/tests/TestCase/File/Path/Basepath/DefaultTraitTest.php
@@ -18,8 +18,8 @@ class DefaultTraitTest extends TestCase
         $mock->field = 'field';
         $mock->entity->expects($this->once())->method('get')->will($this->returnValue(1));
         $mock->table->expects($this->once())->method('alias')->will($this->returnValue('Table'));
-        $mock->table->expects($this->once())->method('primaryKey')->will($this->returnValue('id'));
-        $this->assertEquals('webroot/files/Table/field/', $mock->basepath());
+        $mock->table->expects($this->exactly(2))->method('primaryKey')->will($this->returnValue('id'));
+        $this->assertEquals('webroot/files/Table/field/1', $mock->basepath());
     }
 
     public function testCustomPath()


### PR DESCRIPTION
Hi,

simply adding the `{primaryKey}` to be in the path by default.