### PR TITLE
Prevent erasing _config that's been set in the constructor

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,6 +21,7 @@
         <blacklist>
             <directory suffix=".php">./docs</directory>
             <directory suffix=".php">./vendor</directory>
+            <directory suffix=".php">./tests</directory>
             <file>./tests/bootstrap.php</file>
         </blacklist>
     </filter>

--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -34,7 +34,6 @@ class UploadBehavior extends Behavior
             }
         }
 
-        $this->_config = [];
         $this->config($configs);
 
         Type::map('upload.file', 'Josegonzalez\Upload\Database\Type\FileType');

--- a/tests/Fixture/FilesFixture.php
+++ b/tests/Fixture/FilesFixture.php
@@ -1,0 +1,41 @@
+<?php
+namespace Josegonzalez\Upload\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+class FilesFixture extends TestFixture
+{
+    public $table = 'files';
+
+    /**
+     * fields property
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'filename' => ['type' => 'integer'],
+        'created' => ['type' => 'datetime', 'null' => true],
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
+    ];
+
+    /**
+     * records property
+     *
+     * @var array
+     */
+    public $records = [
+        ['filename' => 'FileOne'],
+        ['filename' => 'FileTwo'],
+        ['filename' => 'FileThree'],
+    ];
+
+    public function init()
+    {
+        $created = $modified = date('Y-m-d H:i:s');
+        array_walk($this->records, function (&$record) use ($created, $modified) {
+            $record += compact('created');
+        });
+        parent::init();
+    }
+}

--- a/tests/Stub/ChildBehavior.php
+++ b/tests/Stub/ChildBehavior.php
@@ -1,0 +1,9 @@
+<?php
+namespace Josegonzalez\Upload\Test\Stub;
+
+use Josegonzalez\Upload\Model\Behavior\UploadBehavior;
+
+class ChildBehavior extends UploadBehavior
+{
+    protected $_defaultConfig = ['key' => 'value'];
+}

--- a/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
@@ -5,12 +5,22 @@ use ArrayObject;
 use Cake\Event\Event;
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Josegonzalez\Upload\Model\Behavior\UploadBehavior;
 use ReflectionClass;
 
+class ChildBehavior extends UploadBehavior
+{
+    protected $_defaultConfig = ['key' => 'value'];
+}
+
 class UploadBehaviorTest extends TestCase
 {
+    public $fixtures = [
+        'plugin.Josegonzalez/Upload.Files',
+    ];
+
     public function setup()
     {
         $this->entity = $this->getMock('Cake\ORM\Entity');
@@ -69,6 +79,16 @@ class UploadBehaviorTest extends TestCase
                  ->will($this->returnValue($this->settings));
 
         $behavior->initialize($this->settings);
+    }
+
+    public function testInheritedConfig()
+    {
+        $table = TableRegistry::get('Josegonzales/Upload.Files');
+        $behavior = new ChildBehavior($table, []);
+
+        $result = $behavior->config();
+        $expected = ['key' => 'value'];
+        $this->assertEquals($expected, $result);
     }
 
     public function testInitializeIndexedConfig()

--- a/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
@@ -8,12 +8,8 @@ use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Josegonzalez\Upload\Model\Behavior\UploadBehavior;
+use Josegonzalez\Upload\Test\Stub\ChildBehavior;
 use ReflectionClass;
-
-class ChildBehavior extends UploadBehavior
-{
-    protected $_defaultConfig = ['key' => 'value'];
-}
 
 class UploadBehaviorTest extends TestCase
 {


### PR DESCRIPTION
I made this change in PR #335 but it got dropped in issue ~~#368~~ #378 because I didnt write a test for it.

I added a test case for an inherited behavior. This doesn't break the test added for indexed config.