### PR TITLE
AfterDelete doesn't detect path of file correctly

### DIFF
--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -120,9 +120,9 @@ class UploadBehavior extends Behavior
                 continue;
             }
 
-            $dirField = Hash::get($settings, 'fields.dir', 'dir');
+            $path = $this->getPathProcessor($entity, $entity->{$field}, $field, $settings)->basepath();
 
-            $file = [$entity->{$dirField} . $entity->{$field}];
+            $file = [$path . $entity->{$field}];
             $writer = $this->getWriter($entity, [], $field, $settings);
             $success = $writer->delete($file);
 

--- a/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
@@ -235,6 +235,9 @@ class UploadBehaviorTest extends TestCase
         $behavior->config($this->dataOk);
 
         $behavior->expects($this->any())
+            ->method('getPathProcessor')
+            ->willReturn($this->processor);
+        $behavior->expects($this->any())
                  ->method('getWriter')
                  ->will($this->returnValue($this->writer));
         $this->writer->expects($this->any())
@@ -250,6 +253,9 @@ class UploadBehaviorTest extends TestCase
         $behavior = $this->getMock('Josegonzalez\Upload\Model\Behavior\UploadBehavior', $methods, [$this->table, $this->dataOk]);
         $behavior->config($this->dataOk);
 
+        $behavior->expects($this->any())
+            ->method('getPathProcessor')
+            ->willReturn($this->processor);
         $behavior->expects($this->any())
                  ->method('getWriter')
                  ->will($this->returnValue($this->writer));
@@ -274,6 +280,33 @@ class UploadBehaviorTest extends TestCase
             ->will($this->returnValue([true]));
 
         $this->assertNull($behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject));
+    }
+
+    public function testAfterDeleteUsesPathProcessorToDetectPathToTheFile()
+    {
+        $this->entity->field = rand(1000, 9999);
+        $path = rand(1000, 9999) . DIRECTORY_SEPARATOR;
+        $methods = array_diff($this->behaviorMethods, ['config', 'afterDelete']);
+        $behavior = $this->getMock('Josegonzalez\Upload\Model\Behavior\UploadBehavior', $methods, [$this->table, $this->dataOk]);
+        $behavior->config($this->dataOk);
+
+        // expecting getPathProcessor to be called with right arguments for dataOk
+        $behavior->expects($this->once())->method('getPathProcessor')
+            ->with($this->entity, $this->entity->field, 'field', $this->dataOk['field'])
+            ->willReturn($this->processor);
+        // basepath of processor should return our fake path
+        $this->processor->expects($this->once())->method('basepath')
+            ->willReturn($path);
+        // expecting getWriter to be called with right arguments for dataOk
+        $behavior->expects($this->once())->method('getWriter')
+            ->with($this->entity, [], 'field', $this->dataOk['field'])
+            ->willReturn($this->writer);
+        // and here we check that file with right path will be deleted
+        $this->writer->expects($this->once())->method('delete')
+            ->with([$path . $this->entity->field])
+            ->willReturn([true]);
+
+        $behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject);
     }
 
     public function testGetWriter()


### PR DESCRIPTION
it tried to get path from `$entity->dir` but by default it's empty and generated file path is `'dir' . $entity->{$field}`: 'dir/myfile.jpg' instead of `webroot/Entity/Field/myfile.php`.
To fix this we're going to use pathProcessor to detect correct path to the file.
Also added UT.

@josegonzalez could you review?