### PR TITLE
Possibility to restore original value of the field when upload failed.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -65,3 +65,7 @@ passed in under each field in your behavior configuration.
 -  ``keepFilesOnDelete``: Keep *all* files when deleting a record.
 
    -  Default: (boolean) ``true``
+
+-  ``restoreValueOnFailure``: Restores original value of the current field when uploaded file has error
+
+   - Defaults: (boolean) ``true``

--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -81,6 +81,10 @@ class UploadBehavior extends Behavior
     {
         foreach ($this->config() as $field => $settings) {
             if (Hash::get((array)$entity->get($field), 'error') !== UPLOAD_ERR_OK) {
+                if (Hash::get($settings, 'restoreValueOnFailure', true)) {
+                    $entity->set($field, $entity->getOriginal($field));
+                    $entity->dirty($field, false);
+                }
                 continue;
             }
 


### PR DESCRIPTION
It helps to keep original value if we just have file field on form and don't want to upload it but keep original file.

@josegonzalez, could you review?