### PR TITLE
Add support for field-value replacements

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -28,10 +28,19 @@ passed in under each field in your behavior configuration.
       -  {DS}: Replaced by a ``DIRECTORY_SEPARATOR``
       -  {model}: Replaced by the Table-alias() method.
       -  {table}: Replaced by the Table->table() method.
-      -  {field}: Replaced by the field name.
+      -  {field}: Replaced by the name of the field which will store
+         the upload filename.
+      -  {field-value:(\w+)}: Replaced by value contained in the
+         current entity in the specified field. As an example, if
+         your path has ``{field-value:unique_id}`` and the entity
+         being saved has a value of ``4b3403665fea6`` for the field
+         ``unique_id``, then ``{field-value:unique_id}`` will be
+         replaced with ``4b3403665fea6``. This replacement can be used
+         multiple times for one or more fields. If the value is not
+         a string or zero-length, a LogicException will be thrown.
       -  {primaryKey}: Replaced by the entity primary key, when
-         available. If used on a new record being created, will have
-         undefined behavior.
+         available. If used on a new record being created, a
+         LogicException will be thrown.
       -  {year}: Replaced by ``date('Y')``
       -  {month}: Replaced by ``date('m')``
       -  {day}: Replaced by ``date('d')``

--- a/src/File/Path/Basepath/DefaultTrait.php
+++ b/src/File/Path/Basepath/DefaultTrait.php
@@ -40,6 +40,21 @@ trait DefaultTrait
             '{DS}' => DIRECTORY_SEPARATOR,
         ];
 
+        if (preg_match_all("/{field-value:(\w+)}/", $path, $matches)) {
+            foreach ($matches[1] as $field) {
+                $value = $this->entity->get($field);
+                if ($value === null) {
+                    throw new LogicException(sprintf('Field value for substitution is missing: %s', $field));
+                }if (!is_scalar($value)) {
+                    throw new LogicException(sprintf('Field value for substitution must be a integer, float, string or boolean: %s', $field));
+                } elseif (strlen($value) < 1) {
+                    throw new LogicException(sprintf('Field value for substitution must be non-zero in length: %s', $field));
+                }
+
+                $replacements[sprintf('{field-value:%s}', $field)] = $value;
+            }
+        }
+
         return str_replace(
             array_keys($replacements),
             array_values($replacements),

--- a/tests/TestCase/File/Path/Basepath/DefaultTraitTest.php
+++ b/tests/TestCase/File/Path/Basepath/DefaultTraitTest.php
@@ -61,7 +61,7 @@ class DefaultTraitTest extends TestCase
         $mock->data = ['name' => 'filename'];
         $mock->field = 'field';
         $mock->entity->expects($this->once())->method('isNew')->will($this->returnValue(true));
-        $this->assertEquals('webroot/files/Table-field/1/', $mock->basepath());
+        $mock->basepath();
     }
 
     public function testExitingEntityWithCompositePrimaryKey()
@@ -76,7 +76,7 @@ class DefaultTraitTest extends TestCase
         $mock->field = 'field';
         $mock->entity->expects($this->once())->method('isNew')->will($this->returnValue(false));
         $mock->table->expects($this->once())->method('primaryKey')->will($this->returnValue(['id', 'other_id']));
-        $this->assertEquals('webroot/files/Table-field/1/', $mock->basepath());
+        $mock->basepath();
     }
 
     public function testYearWithMonthPath()
@@ -117,5 +117,60 @@ class DefaultTraitTest extends TestCase
         $mock->table->expects($this->once())->method('alias')->will($this->returnValue('Table'));
 
         $this->assertEquals('webroot/files/Table/field/' . date("Y") . '/' . date("m") . '/' . date("d") . '/', $mock->basepath());
+    }
+
+    public function testFieldValueMissing()
+    {
+        $this->setExpectedException('LogicException', 'Field value for substitution is missing: field');
+
+        $mock = $this->getMockForTrait('Josegonzalez\Upload\File\Path\Basepath\DefaultTrait');
+        $mock->entity = $this->getMock('Cake\ORM\Entity');
+        $mock->table = $this->getMock('Cake\ORM\Table');
+        $mock->settings = ['path' => 'webroot{DS}files{DS}{model}{DS}{field-value:field}{DS}'];
+        $mock->data = ['name' => 'filename'];
+        $mock->field = 'field';
+        $mock->entity->expects($this->any())->method('get')->will($this->returnValue(null));
+        $mock->basepath();
+    }
+
+    public function testFieldValueNonScalar()
+    {
+        $this->setExpectedException('LogicException', 'Field value for substitution must be a integer, float, string or boolean: field');
+
+        $mock = $this->getMockForTrait('Josegonzalez\Upload\File\Path\Basepath\DefaultTrait');
+        $mock->entity = $this->getMock('Cake\ORM\Entity');
+        $mock->table = $this->getMock('Cake\ORM\Table');
+        $mock->settings = ['path' => 'webroot{DS}files{DS}{model}{DS}{field-value:field}{DS}'];
+        $mock->data = ['name' => 'filename'];
+        $mock->field = 'field';
+        $mock->entity->expects($this->any())->method('get')->will($this->returnValue([]));
+        $mock->basepath();
+    }
+
+    public function testFieldValueZeroLength()
+    {
+        $this->setExpectedException('LogicException', 'Field value for substitution must be non-zero in length: field');
+
+        $mock = $this->getMockForTrait('Josegonzalez\Upload\File\Path\Basepath\DefaultTrait');
+        $mock->entity = $this->getMock('Cake\ORM\Entity');
+        $mock->table = $this->getMock('Cake\ORM\Table');
+        $mock->settings = ['path' => 'webroot{DS}files{DS}{model}{DS}{field-value:field}{DS}'];
+        $mock->data = ['name' => 'filename'];
+        $mock->field = 'field';
+        $mock->entity->expects($this->any())->method('get')->will($this->returnValue(''));
+        $mock->basepath();
+    }
+
+    public function testFieldValue()
+    {
+        $mock = $this->getMockForTrait('Josegonzalez\Upload\File\Path\Basepath\DefaultTrait');
+        $mock->entity = $this->getMock('Cake\ORM\Entity');
+        $mock->table = $this->getMock('Cake\ORM\Table');
+        $mock->settings = ['path' => 'webroot{DS}files{DS}{model}{DS}{field-value:field}{DS}'];
+        $mock->data = ['name' => 'filename'];
+        $mock->field = 'field';
+        $mock->entity->expects($this->any())->method('get')->will($this->returnValue('value'));
+        $mock->table->expects($this->once())->method('alias')->will($this->returnValue('Table'));
+        $this->assertEquals('webroot/files/Table/value/', $mock->basepath());
     }
 }


### PR DESCRIPTION
The pattern `{field-value:(\w+)}` is replaced by value contained in the current entity in the specified field. As an example, if your path has `{field-value:unique_id}` and the entity being saved has a value of `4b3403665fea6` for the field `unique_id`, then `{field-value:unique_id}` will be replaced with `4b3403665fea6`. This replacement can be used multiple times for one or more fields.

If the value is not a string or zero-length, a LogicException will be thrown.