### PR TITLE
Fixed error when class name was specified

### DIFF
--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -35,6 +35,7 @@ class UploadBehavior extends Behavior
         }
 
         $this->config($configs);
+        $this->config('className', null);
 
         Type::map('upload.file', 'Josegonzalez\Upload\Database\Type\FileType');
         $schema = $this->_table->schema();

--- a/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
@@ -70,7 +70,7 @@ class UploadBehaviorTest extends TestCase
         $property->setAccessible(true);
         $property->setValue($behavior, $table);
 
-        $behavior->expects($this->exactly(2))
+        $behavior->expects($this->exactly(3))
                  ->method('config')
                  ->will($this->returnValue($this->settings));
 
@@ -101,6 +101,35 @@ class UploadBehaviorTest extends TestCase
         $table->expects($this->at(1))
               ->method('schema')
               ->will($this->returnValue($schema));
+
+        $methods = array_diff($this->behaviorMethods, ['initialize', 'config']);
+        $behavior = $this->getMock('Josegonzalez\Upload\Model\Behavior\UploadBehavior', $methods, [$table, $settings], '', false);
+        $reflection = new ReflectionClass($behavior);
+        $property = $reflection->getProperty('_table');
+        $property->setAccessible(true);
+        $property->setValue($behavior, $table);
+        $behavior->initialize($settings);
+
+        $this->assertEquals(['field' => []], $behavior->config());
+    }
+
+    public function testInitializeAddBehaviorOptionsInterfaceConfig()
+    {
+        $settings = [
+            'className' => 'Josegonzalez\Upload\Model\Behavior\UploadBehavior',
+            'field' => []
+        ];
+        $table = $this->getMock('Cake\ORM\Table');
+        $schema = $this->getMock('Cake\Database\Schema\Table', [], [$table, []]);
+        $schema->expects($this->once())
+            ->method('columnType')
+            ->with('field', 'upload.file');
+        $table->expects($this->at(0))
+            ->method('schema')
+            ->will($this->returnValue($schema));
+        $table->expects($this->at(1))
+            ->method('schema')
+            ->will($this->returnValue($schema));
 
         $methods = array_diff($this->behaviorMethods, ['initialize', 'config']);
         $behavior = $this->getMock('Josegonzalez\Upload\Model\Behavior\UploadBehavior', $methods, [$table, $settings], '', false);


### PR DESCRIPTION
I corrected the error in this case.

```php
$this->addBehavior('Upload', [
    'className' => 'Josegonzalez\Upload\Model\Behavior\UploadBehavior',
    'field' => []
]);
```